### PR TITLE
feat-docs-byok-aws-bedrock-integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -16,11 +16,7 @@
           {
             "group": "Start Here",
             "icon": "rocket",
-            "pages": [
-              "index",
-              "quickstart",
-              "guide/code-review"
-            ]
+            "pages": ["index", "quickstart", "guide/code-review"]
           },
           {
             "group": "Infrastructure",
@@ -38,6 +34,7 @@
             "icon": "gear",
             "pages": [
               "guide/workspaces",
+              "guide/byok",
               {
                 "group": "Connections",
                 "icon": "plug",
@@ -82,9 +79,7 @@
           {
             "group": "Reference",
             "icon": "book",
-            "pages": [
-              "learn/faq"
-            ]
+            "pages": ["learn/faq"]
           }
         ]
       }

--- a/docs.json
+++ b/docs.json
@@ -34,7 +34,6 @@
             "icon": "gear",
             "pages": [
               "guide/workspaces",
-              "guide/byok",
               {
                 "group": "Connections",
                 "icon": "plug",
@@ -65,7 +64,8 @@
               },
               "guide/knowledge",
               "guide/notifications",
-              "guide/slack-integration"
+              "guide/slack-integration",
+              "guide/byok"
             ]
           },
           {

--- a/guide/byok.mdx
+++ b/guide/byok.mdx
@@ -1,0 +1,316 @@
+---
+title: Bring Your Own Key (BYOK)
+description: "Use your own AWS Bedrock credentials for unlimited LLM usage"
+icon: key
+---
+
+Bring Your Own Key (BYOK) allows Advanced and Enterprise plan users to use their own AWS Bedrock credentials for LLM operations. This enables unlimited usage without consuming platform credits, provides cost control through your own AWS billing, and supports data residency requirements.
+
+---
+
+## Benefits
+
+- **Unlimited Usage** - No credit restrictions when using your own credentials
+- **Cost Control** - Charges appear on your AWS bill, giving you full visibility and control
+- **Data Residency** - Route requests through specific AWS regions (US, EU, APAC) for compliance
+- **Automatic Model Selection** - System automatically chooses optimal models
+- **Seamless Fallback** - Automatically falls back to platform credentials if your credentials fail
+
+---
+
+## Prerequisites
+
+- **Advanced or Enterprise subscription plan** - BYOK is only available for Advanced and Enterprise tier users
+- **AWS account** with Amazon Bedrock access enabled
+- **IAM credentials** with Bedrock permissions (access key ID and secret access key)
+- **Model access** - Both Claude Sonnet 4.5 and Opus 4.5 models must be enabled in your AWS account
+
+---
+
+## Supported Providers
+
+<Tabs>
+  <Tab title="AWS IAM (Current)">
+    ### AWS IAM Credentials
+
+    Use your AWS IAM user or role credentials to authenticate with Amazon Bedrock.
+
+    **Required Credentials:**
+    - Access Key ID
+    - Secret Access Key
+    - Session Token (optional, for temporary credentials)
+
+    **Benefits:**
+    - Works with existing IAM users and roles
+    - Supports temporary credentials via AWS STS
+    - Automatic token refresh for session tokens
+    - Full integration with AWS security policies
+
+    <Info>
+    Long-term credentials (AKIA prefix) enable automatic session token refresh. Temporary credentials (ASIA prefix) cannot be automatically refreshed.
+    </Info>
+
+  </Tab>
+
+  <Tab title="Bedrock API Keys (Coming Soon)">
+    ### Bedrock API Keys
+
+    Direct API key authentication for Amazon Bedrock will be available in a future release.
+
+    This will provide:
+    - Simplified credential management
+    - Direct API key authentication
+    - No IAM policy configuration required
+
+    <Warning>
+    Bedrock API Keys are not yet available. Currently, only AWS IAM credentials are supported.
+    </Warning>
+
+  </Tab>
+</Tabs>
+
+---
+
+## AWS Bedrock Model Access
+
+Before configuring BYOK, you must request access to Claude models in your AWS account. While AWS has simplified access for many serverless models (granted automatically upon first invocation), Claude models still require manual approval via a use case form. For more information, refer to the [AWS Bedrock Model Access documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html).
+
+### Request Access to Claude Models
+
+<Steps>
+  <Step title="Open Amazon Bedrock Console">
+    Log in to [AWS Console](https://console.aws.amazon.com/) and navigate to
+    [Amazon Bedrock](https://console.aws.amazon.com/bedrock/)
+  </Step>
+  <Step title="Navigate to Model Access">
+    In the left navigation pane, click **Model access**
+  </Step>
+  <Step title="Modify Model Access">Click **Modify model access** button</Step>
+  <Step title="Select Claude Models">
+    Enable access to both: - **Claude Sonnet 4.5**
+    (`anthropic.claude-sonnet-4-5-20250929-v1:0`) - **Claude Opus 4.5**
+    (`anthropic.claude-opus-4-5-20251101-v1:0`)
+  </Step>
+  <Step title="Submit Use Case Details">
+    Click **Submit use case details** and complete the form with: - Your use
+    case description - Expected usage patterns - Compliance requirements (if
+    applicable)
+  </Step>
+  <Step title="Wait for Approval">
+    Access is typically granted immediately upon successful submission. You'll
+    receive confirmation when access is enabled.
+  </Step>
+</Steps>
+
+<Info>
+  **Important:** You must request access to **both** Sonnet 4.5 and Opus 4.5
+  models. CloudThinker automatically selects the appropriate model based on task
+  requirements.
+</Info>
+
+---
+
+## Required IAM Permissions
+
+Your AWS IAM user or role must have permissions to invoke Bedrock models. Create an IAM policy with the following permissions:
+
+### Minimum Required Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0"
+      ]
+    }
+  ]
+}
+```
+
+### Policy with Inference Profiles
+
+If you plan to use inference profiles (global, us, eu, apac), include additional resource ARNs:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": [
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/global.anthropic.claude-opus-4-5-20251101-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/us.anthropic.claude-opus-4-5-20251101-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/eu.anthropic.claude-opus-4-5-20251101-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/apac.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "arn:aws:bedrock:*:*:inference-profile/apac.anthropic.claude-opus-4-5-20251101-v1:0"
+      ]
+    }
+  ]
+}
+```
+
+### Additional Permissions for Token Refresh
+
+If using long-term credentials (AKIA prefix), CloudThinker can automatically refresh session tokens. Add STS permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["sts:GetSessionToken"],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+---
+
+## Setup in CloudThinker
+
+Once you have AWS Bedrock model access and IAM credentials configured, set up BYOK in CloudThinker:
+
+<Steps>
+  <Step title="Navigate to BYOK Settings">
+    Go to **Settings** → **BYOK Settings** (or navigate to `/byok-settings` in
+    the app)
+  </Step>
+  <Step title="Select AWS Bedrock">
+    Choose **AWS Bedrock** as your provider
+  </Step>
+  <Step title="Enter Credentials">
+    Provide your AWS credentials: - **Access Key ID** - Your AWS access key
+    (AKIA or ASIA prefix) - **Secret Access Key** - Your AWS secret key -
+    **Session Token** (optional) - Required only for temporary credentials
+  </Step>
+  <Step title="Select Inference Profile">
+    Choose an inference profile: - **Global** - Routes to any commercial AWS
+    region (~10% cost savings) - **US** - Routes within US regions only - **EU**
+    - Routes within EU regions only (data residency) - **APAC** - Routes within
+    APAC regions only - **Regional** - Single region (requires explicit region
+    selection)
+  </Step>
+  <Step title="Select Region (if Regional)">
+    If you selected "Regional" profile, choose your AWS region from the dropdown
+  </Step>
+  <Step title="Test Connection">
+    Click **Test Connection** to verify: - Credentials are valid - Both Sonnet
+    4.5 and Opus 4.5 models are accessible - Permissions are correctly
+    configured
+  </Step>
+  <Step title="Save Configuration">
+    After successful test, click **Save** to store your BYOK configuration
+  </Step>
+</Steps>
+
+<Warning>
+  Credentials are encrypted and stored securely. They are never exposed in API
+  responses or logs. Only Advanced and Enterprise plan users can configure BYOK.
+</Warning>
+
+---
+
+## Inference Profiles
+
+Bedrock inference profiles control how requests are routed across AWS regions. Choose the profile that best matches your requirements:
+
+| Profile      | Purpose                                                              |
+| ------------ | -------------------------------------------------------------------- |
+| **Global**   | Routes to any commercial AWS region for maximum throughput           |
+| **US**       | Routes within US regions only for US data residency                 |
+| **EU**       | Routes within EU regions only for GDPR compliance                   |
+| **APAC**     | Routes within APAC regions only for regional data residency         |
+| **Regional** | Routes to a single AWS region for strict data residency             |
+
+<Info>
+  The Regional profile provides the most control but may have higher latency and cost compared to inference profiles that can route across multiple regions. For supported regions, refer to the [AWS Bedrock Supported Regions and Models documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).
+</Info>
+
+---
+
+## How It Works
+
+### Automatic Model Selection
+
+CloudThinker automatically selects the optimal model based on task requirements. You don't need to manually select models - the system chooses the best option automatically. For more details about the available models, refer to the [AWS Bedrock Supported Foundation Models documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html).
+
+### Workspace Owner Inheritance
+
+When a workspace owner configures BYOK, all workspace members automatically inherit access to those credentials. This means:
+
+- Workspace owner configures BYOK once
+- All members can use BYOK without individual configuration
+- Credentials are managed centrally by the workspace owner
+- Members' LLM usage routes through the owner's AWS account
+
+### Fallback Mechanism
+
+If your BYOK credentials fail (due to rate limits, expired tokens, or permission issues), CloudThinker automatically falls back to platform credentials. This ensures:
+
+- No service interruption
+- Seamless user experience
+- Automatic recovery when credentials are restored
+
+---
+
+## Troubleshooting
+
+<Accordion title="Model access denied errors">
+  - Verify you've submitted the use case form in Bedrock Console - Check that
+  both Sonnet 4.5 and Opus 4.5 models are enabled - Confirm access was granted
+  (check Model access page in Bedrock Console) - Wait a few minutes after form
+  submission for access to propagate
+</Accordion>
+
+<Accordion title="IAM permission errors">
+  - Verify your IAM policy includes `bedrock:InvokeModel` and
+  `bedrock:InvokeModelWithResponseStream` - Check that model ARNs in the policy
+  match the models you're using - Ensure inference profile ARNs are included if
+  using profiles (global, us, eu, apac) - Test IAM permissions directly in AWS
+  Console
+</Accordion>
+
+<Accordion title="Credential validation failures">
+  - Verify access key ID and secret access key are correct - Check that
+  credentials haven't been rotated or revoked - For temporary credentials,
+  ensure session token hasn't expired - Test credentials using AWS CLI: `aws sts
+  get-caller-identity`
+</Accordion>
+
+<Accordion title="Test connection fails">
+  - Verify both Sonnet 4.5 and Opus 4.5 models are accessible - Check IAM
+  permissions include both model ARNs - Ensure Bedrock service is enabled in
+  your AWS account - Check AWS region selection matches your model access
+</Accordion>
+
+<Accordion title="BYOK not working in workspace">
+  - Verify workspace owner has configured BYOK - Check that BYOK is enabled (not
+  disabled) in settings - Confirm workspace owner's plan is Advanced or
+  Enterprise - Check workspace owner's credentials are still valid
+</Accordion>
+
+<Accordion title="Session token expiration">
+  - Long-term credentials (AKIA) are automatically refreshed - Temporary
+  credentials (ASIA) cannot be refreshed - reconfigure with new credentials -
+  Check `session_token_expires_at` timestamp in configuration - Reconfigure if
+  automatic refresh fails
+</Accordion>

--- a/guide/byok.mdx
+++ b/guide/byok.mdx
@@ -110,36 +110,20 @@ Before configuring BYOK, you must request access to Claude models in your AWS ac
 
 ---
 
-## Required IAM Permissions
+## IAM Credentials Setup
 
-Your AWS IAM user or role must have permissions to invoke Bedrock models. Create an IAM policy with the following permissions:
+Your AWS IAM user must have permissions to invoke Bedrock models. Follow these steps to create an IAM user with the required permissions using AWS CLI.
 
-### Minimum Required Policy
+### Step 1: Create IAM User
 
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
-      ],
-      "Resource": [
-        "arn:aws:bedrock:*::foundation-model/anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "arn:aws:bedrock:*::foundation-model/anthropic.claude-opus-4-5-20251101-v1:0"
-      ]
-    }
-  ]
-}
+```bash
+aws iam create-user --user-name bedrock-byok-user
 ```
 
-### Policy with Inference Profiles
+### Step 2: Create Policy File
 
-If you plan to use inference profiles (global, us, eu, apac), include additional resource ARNs:
-
-```json
+```bash
+cat > bedrock-policy.json << 'EOF'
 {
   "Version": "2012-10-17",
   "Statement": [
@@ -161,19 +145,7 @@ If you plan to use inference profiles (global, us, eu, apac), include additional
         "arn:aws:bedrock:*:*:inference-profile/apac.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "arn:aws:bedrock:*:*:inference-profile/apac.anthropic.claude-opus-4-5-20251101-v1:0"
       ]
-    }
-  ]
-}
-```
-
-### Additional Permissions for Token Refresh
-
-If using long-term credentials (AKIA prefix), CloudThinker can automatically refresh session tokens. Add STS permissions:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
+    },
     {
       "Effect": "Allow",
       "Action": ["sts:GetSessionToken"],
@@ -181,7 +153,43 @@ If using long-term credentials (AKIA prefix), CloudThinker can automatically ref
     }
   ]
 }
+EOF
 ```
+
+### Step 3: Attach Policy to User
+
+```bash
+aws iam put-user-policy \
+  --user-name bedrock-byok-user \
+  --policy-name BedrockInvokePolicy \
+  --policy-document file://bedrock-policy.json
+```
+
+### Step 4: Create Access Keys
+
+```bash
+aws iam create-access-key --user-name bedrock-byok-user
+```
+
+Save the `AccessKeyId` and `SecretAccessKey` from the output - you'll need these for CloudThinker.
+
+### Step 5: Verify Credentials
+
+Configure a local profile to test the credentials:
+
+```bash
+aws configure --profile bedrock-byok-user
+```
+
+Enter the access key ID and secret access key when prompted. Then verify:
+
+```bash
+aws sts get-caller-identity --profile bedrock-byok-user
+```
+
+<Info>
+These commands require an AWS profile with IAM administrative permissions (`iam:CreateUser`, `iam:PutUserPolicy`, `iam:CreateAccessKey`). Alternatively, you can create the IAM user via the [AWS Console](https://console.aws.amazon.com/iam/).
+</Info>
 
 ---
 
@@ -198,24 +206,24 @@ Once you have AWS Bedrock model access and IAM credentials configured, set up BY
     Choose **AWS Bedrock** as your provider
   </Step>
   <Step title="Enter Credentials">
-    Provide your AWS credentials: - **Access Key ID** - Your AWS access key
-    (AKIA or ASIA prefix) - **Secret Access Key** - Your AWS secret key -
-    **Session Token** (optional) - Required only for temporary credentials
+    Provide your AWS credentials:
+    - **Access Key ID** - Your AWS access key
+      (AKIA or ASIA prefix)
+    - **Secret Access Key** - Your AWS secret key
+    - **Session Token** (optional) - Required only for temporary credentials
   </Step>
   <Step title="Select Inference Profile">
-    Choose an inference profile: - **Global** - Routes to any commercial AWS
-    region (~10% cost savings) - **US** - Routes within US regions only - **EU**
-    - Routes within EU regions only (data residency) - **APAC** - Routes within
-    APAC regions only - **Regional** - Single region (requires explicit region
-    selection)
-  </Step>
-  <Step title="Select Region (if Regional)">
-    If you selected "Regional" profile, choose your AWS region from the dropdown
-  </Step>
+    Choose an inference profile:
+    - **Global** - Routes to any commercial AWS region
+    - **US** - Routes within US regions only
+    - **EU** - Routes within EU regions only (data residency)
+    - **APAC** - Routes within APAC regions only
+  </Step>  
   <Step title="Test Connection">
-    Click **Test Connection** to verify: - Credentials are valid - Both Sonnet
-    4.5 and Opus 4.5 models are accessible - Permissions are correctly
-    configured
+    Click **Test Connection** to verify:
+    - Credentials are valid
+    - Both Sonnet 4.5 and Opus 4.5 models are accessible
+    - Permissions are correctly configured
   </Step>
   <Step title="Save Configuration">
     After successful test, click **Save** to store your BYOK configuration
@@ -239,10 +247,9 @@ Bedrock inference profiles control how requests are routed across AWS regions. C
 | **US**       | Routes within US regions only for US data residency                 |
 | **EU**       | Routes within EU regions only for GDPR compliance                   |
 | **APAC**     | Routes within APAC regions only for regional data residency         |
-| **Regional** | Routes to a single AWS region for strict data residency             |
 
 <Info>
-  The Regional profile provides the most control but may have higher latency and cost compared to inference profiles that can route across multiple regions. For supported regions, refer to the [AWS Bedrock Supported Regions and Models documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).
+  For supported regions and inference profile details, refer to the [AWS Bedrock Supported Regions and Models documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html).
 </Info>
 
 ---

--- a/guide/byok.mdx
+++ b/guide/byok.mdx
@@ -87,14 +87,15 @@ Before configuring BYOK, you must request access to Claude models in your AWS ac
   </Step>
   <Step title="Modify Model Access">Click **Modify model access** button</Step>
   <Step title="Select Claude Models">
-    Enable access to both: - **Claude Sonnet 4.5**
-    (`anthropic.claude-sonnet-4-5-20250929-v1:0`) - **Claude Opus 4.5**
-    (`anthropic.claude-opus-4-5-20251101-v1:0`)
+    Enable access to both:
+    - **Claude Sonnet 4.5** (`anthropic.claude-sonnet-4-5-20250929-v1:0`)
+    - **Claude Opus 4.5** (`anthropic.claude-opus-4-5-20251101-v1:0`)
   </Step>
   <Step title="Submit Use Case Details">
-    Click **Submit use case details** and complete the form with: - Your use
-    case description - Expected usage patterns - Compliance requirements (if
-    applicable)
+    Click **Submit use case details** and complete the form with:
+    - Your use case description
+    - Expected usage patterns
+    - Compliance requirements (if applicable)
   </Step>
   <Step title="Wait for Approval">
     Access is typically granted immediately upon successful submission. You'll
@@ -282,42 +283,43 @@ If your BYOK credentials fail (due to rate limits, expired tokens, or permission
 ## Troubleshooting
 
 <Accordion title="Model access denied errors">
-  - Verify you've submitted the use case form in Bedrock Console - Check that
-  both Sonnet 4.5 and Opus 4.5 models are enabled - Confirm access was granted
-  (check Model access page in Bedrock Console) - Wait a few minutes after form
-  submission for access to propagate
+  - Verify you've submitted the use case form in Bedrock Console
+  - Check that both Sonnet 4.5 and Opus 4.5 models are enabled
+  - Confirm access was granted (check Model access page in Bedrock Console)
+  - Wait a few minutes after form submission for access to propagate
 </Accordion>
 
 <Accordion title="IAM permission errors">
-  - Verify your IAM policy includes `bedrock:InvokeModel` and
-  `bedrock:InvokeModelWithResponseStream` - Check that model ARNs in the policy
-  match the models you're using - Ensure inference profile ARNs are included if
-  using profiles (global, us, eu, apac) - Test IAM permissions directly in AWS
-  Console
+  - Verify your IAM policy includes `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream`
+  - Check that model ARNs in the policy match the models you're using
+  - Ensure inference profile ARNs are included if using profiles (global, us, eu, apac)
+  - Test IAM permissions directly in AWS Console
 </Accordion>
 
 <Accordion title="Credential validation failures">
-  - Verify access key ID and secret access key are correct - Check that
-  credentials haven't been rotated or revoked - For temporary credentials,
-  ensure session token hasn't expired - Test credentials using AWS CLI: `aws sts
-  get-caller-identity`
+  - Verify access key ID and secret access key are correct
+  - Check that credentials haven't been rotated or revoked
+  - For temporary credentials, ensure session token hasn't expired
+  - Test credentials using AWS CLI: `aws sts get-caller-identity`
 </Accordion>
 
 <Accordion title="Test connection fails">
-  - Verify both Sonnet 4.5 and Opus 4.5 models are accessible - Check IAM
-  permissions include both model ARNs - Ensure Bedrock service is enabled in
-  your AWS account - Check AWS region selection matches your model access
+  - Verify both Sonnet 4.5 and Opus 4.5 models are accessible
+  - Check IAM permissions include both model ARNs
+  - Ensure Bedrock service is enabled in your AWS account
+  - Check AWS region selection matches your model access
 </Accordion>
 
 <Accordion title="BYOK not working in workspace">
-  - Verify workspace owner has configured BYOK - Check that BYOK is enabled (not
-  disabled) in settings - Confirm workspace owner's plan is Advanced or
-  Enterprise - Check workspace owner's credentials are still valid
+  - Verify workspace owner has configured BYOK
+  - Check that BYOK is enabled (not disabled) in settings
+  - Confirm workspace owner's plan is Advanced or Enterprise
+  - Check workspace owner's credentials are still valid
 </Accordion>
 
 <Accordion title="Session token expiration">
-  - Long-term credentials (AKIA) are automatically refreshed - Temporary
-  credentials (ASIA) cannot be refreshed - reconfigure with new credentials -
-  Check `session_token_expires_at` timestamp in configuration - Reconfigure if
-  automatic refresh fails
+  - Long-term credentials (AKIA) are automatically refreshed
+  - Temporary credentials (ASIA) cannot be refreshed - reconfigure with new credentials
+  - Check `session_token_expires_at` timestamp in configuration
+  - Reconfigure if automatic refresh fails
 </Accordion>

--- a/guide/connections/aws.mdx
+++ b/guide/connections/aws.mdx
@@ -110,6 +110,7 @@ CloudThinker supports two authentication methods. **Role-Based authentication is
       ]
     }
     ```
+
   </Tab>
 
   <Tab title="Access Keys (Alternative)">
@@ -143,6 +144,7 @@ CloudThinker supports two authentication methods. **Role-Based authentication is
         - Secret Access Key
       </Step>
     </Steps>
+
   </Tab>
 </Tabs>
 
@@ -182,12 +184,12 @@ cloudtrail:Describe*, cloudtrail:Get*
 
 Once connected, agents can:
 
-| Agent | AWS Capabilities |
-|-------|------------------|
-| **Alex** | Cost analysis, EC2 right-sizing, Reserved Instance recommendations, resource optimization |
-| **Oliver** | Security Hub findings, IAM audits, compliance checks, vulnerability assessment |
-| **Tony** | RDS performance analysis, Aurora optimization, DynamoDB tuning |
-| **Kai** | EKS cluster management, Fargate optimization, container analysis |
+| Agent      | AWS Capabilities                                                                          |
+| ---------- | ----------------------------------------------------------------------------------------- |
+| **Alex**   | Cost analysis, EC2 right-sizing, Reserved Instance recommendations, resource optimization |
+| **Oliver** | Security Hub findings, IAM audits, compliance checks, vulnerability assessment            |
+| **Tony**   | RDS performance analysis, Aurora optimization, DynamoDB tuning                            |
+| **Kai**    | EKS cluster management, Fargate optimization, container analysis                          |
 
 ---
 
@@ -207,7 +209,11 @@ For organizations with multiple AWS accounts:
   </Step>
 </Steps>
 
-<Card title="Multi-Account Guide" icon="building" href="/guide/use-cases/multi-aws-accounts">
+<Card
+  title="Multi-Account Guide"
+  icon="building"
+  href="/guide/use-cases/multi-aws-accounts"
+>
   Detailed guide for managing multiple AWS accounts
 </Card>
 
@@ -216,28 +222,26 @@ For organizations with multiple AWS accounts:
 ## Troubleshooting
 
 <Accordion title="Access Denied errors">
-- Verify IAM role has required permissions
-- Check trust policy includes CloudThinker's account
-- Confirm External ID matches exactly
-- Ensure role ARN is correct
+  - Verify IAM role has required permissions - Check trust policy includes
+  CloudThinker's account - Confirm External ID matches exactly - Ensure role ARN
+  is correct
 </Accordion>
 
 <Accordion title="Missing cost data">
-- Enable Cost Explorer in AWS Console (takes 24h to activate)
-- Verify `ce:GetCost*` permissions are granted
-- Check billing preferences allow programmatic access
+  - Enable Cost Explorer in AWS Console (takes 24h to activate) - Verify
+  `ce:GetCost*` permissions are granted - Check billing preferences allow
+  programmatic access
 </Accordion>
 
 <Accordion title="Missing metrics">
-- Verify CloudWatch metrics are being collected
-- Check region selection includes all relevant regions
-- Confirm services are running and generating data
+  - Verify CloudWatch metrics are being collected - Check region selection
+  includes all relevant regions - Confirm services are running and generating
+  data
 </Accordion>
 
 <Accordion title="Connection timeout">
-- Check network connectivity to AWS APIs
-- Verify no VPC endpoints blocking access
-- Try connecting from a different region
+  - Check network connectivity to AWS APIs - Verify no VPC endpoints blocking
+  access - Try connecting from a different region
 </Accordion>
 
 ---
@@ -258,7 +262,14 @@ For organizations with multiple AWS accounts:
   <Card title="Alex Agent" icon="cloud" href="/guide/agents/alex">
     AWS-focused cloud optimization agent
   </Card>
-  <Card title="Multi-Account Setup" icon="building" href="/guide/use-cases/multi-aws-accounts">
+  <Card
+    title="Multi-Account Setup"
+    icon="building"
+    href="/guide/use-cases/multi-aws-accounts"
+  >
     Managing multiple AWS accounts
+  </Card>
+  <Card title="Bring Your Own Key (BYOK)" icon="key" href="/guide/byok">
+    Use your own AWS Bedrock credentials for unlimited LLM usage
   </Card>
 </CardGroup>


### PR DESCRIPTION
What changed
- Added a comprehensive BYOK (Bring Your Own Key) guide for AWS Bedrock integration covering benefits, prerequisites, supported providers, model access request steps, IAM permission details, CloudThinker setup, inference profiles, credential handling, and workspace owner inheritance.
- Replaced the static IAM policy JSON with a reproducible AWS CLI walkthrough to create an IAM user, attach a Bedrock invoke policy, create access keys, and verify credentials.
- Reformatted and clarified credential entry instructions, inference profile explanations, and testing steps.
- Improved readability and navigation: reflowed lists, expanded troubleshooting bullets, and moved the BYOK guide under the Connections group in the docs sidebar.

Why this matters
- Makes BYOK setup for Advanced and Enterprise users practical and secure, reducing onboarding friction and support needs.
- Provides clear, step-by-step CLI instructions that users can follow to provision correct AWS permissions and validate credentials.
- Enhances documentation clarity and discoverability for common BYOK issues and model access requirements.

Notes for reviewers
- Verify content accuracy for IAM CLI commands and Bedrock model access steps.
- Confirm sidebar change and formatting align with docs style guidelines.