### PR TITLE
fix(docs): update Discord links to use HTTPS

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -117,7 +117,7 @@
         },
         {
           "anchor": "Community",
-          "href": "http://discord.com/invite/sRBWRWtaNR",
+          "href": "https://discord.com/invite/sRBWRWtaNR",
           "icon": "discord"
         },
         {
@@ -150,7 +150,7 @@
       "x": "https://x.com/cloudthinkerio?s=21",
       "linkedin": "https://www.linkedin.com/company/cloud-thinker",
       "github": "https://github.com/Cloud-Thinker-AI",
-      "discord": "http://discord.com/invite/sRBWRWtaNR",
+      "discord": "https://discord.com/invite/sRBWRWtaNR",
       "youtube": "https://www.youtube.com/@CloudThinker-1224"
     }
   }


### PR DESCRIPTION
Changed Discord invitation links in docs.json from HTTP to HTTPS for improved security and consistency across documentation.