### PR TITLE
fix: update GitHub link in documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -230,7 +230,7 @@
     "socials": {
       "x": "https://x.com/cloudthinkerio?s=21",
       "linkedin": "https://www.linkedin.com/company/cloud-thinker",
-      "github": "https://github.com/Cloud-Thinker-AI",
+      "github": "https://github.com/cloudthinker-ai",
       "discord": "https://discord.com/invite/sRBWRWtaNR",
       "youtube": "https://www.youtube.com/@CloudThinker-1224"
     }


### PR DESCRIPTION
Correct the GitHub URL in the socials section of the documentation to reflect the accurate repository address.