### PR TITLE
feat(docs): add MCP tool details to Datadog integration guide

### DIFF
--- a/guide/connections/datadog.mdx
+++ b/guide/connections/datadog.mdx
@@ -79,6 +79,13 @@ Always use scoped Application Keys instead of unscoped ones. This follows the pr
 
 When creating your Application Key, select these scopes to enable all CloudThinker tools:
 
+### MCP
+
+| Tool | What it does | Requires |
+|------|--------------|----------|
+| `mcp_read` | Read data via the MCP server. | Read scopes (see below) |
+| `mcp_write` | Write data via the MCP server. | `notebooks_write` + user approval |
+
 ### Read Scopes (all read tools)
 
 | Scope | Enables |


### PR DESCRIPTION
- Introduce a new section detailing the MCP tool, including its read and write capabilities.
- Specify the required scopes for using the MCP tool effectively.