### PR TITLE
docs: add MongoDB connection guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.worktrees/

--- a/docs.json
+++ b/docs.json
@@ -118,6 +118,7 @@
               "guide/connections/cloudflare",
               "guide/connections/postgresql",
               "guide/connections/mysql",
+              "guide/connections/mongodb",
               "guide/connections/kubernetes",
               "guide/connections/elasticsearch",
               "guide/connections/grafana",

--- a/guide/connections/mongodb.mdx
+++ b/guide/connections/mongodb.mdx
@@ -1,0 +1,218 @@
+---
+title: MongoDB
+description: "Connect MongoDB databases to CloudThinker"
+icon: leaf
+---
+
+# MongoDB
+
+Connect your MongoDB databases to enable [Tony](/guide/agents/tony) (Database Engineer) to analyze queries, optimize performance, and monitor database health.
+
+---
+
+## Supported Platforms
+
+| Platform | Support |
+|----------|---------|
+| **Self-hosted MongoDB** | 4.x, 5.x, 6.x, 7.x |
+| **MongoDB Atlas** | All versions |
+| **AWS DocumentDB** | Elastic Clusters, Instance-based Clusters |
+
+---
+
+## Setup
+
+Select your MongoDB platform for specific connection instructions:
+
+<Tabs>
+  <Tab title="Self-hosted MongoDB">
+    <Steps>
+      <Step title="Connect as Admin">
+        Connect to your MongoDB instance using the Mongo shell (`mongosh`) with administrative privileges:
+        ```bash
+        mongosh "mongodb://admin-user:admin-password@your-host:27017/admin"
+        ```
+      </Step>
+      <Step title="Switch to Admin Database">
+        Ensure you are on the `admin` database where users are created:
+        ```javascript
+        use admin
+        ```
+      </Step>
+      <Step title="Create Read-Only User">
+        Create a dedicated user for CloudThinker with the `readAnyDatabase` role:
+        ```javascript
+        db.createUser({
+          user: "cloudthinker_readonly",
+          pwd: "your-secure-password",
+          roles: [
+            { role: "readAnyDatabase", db: "admin" },
+            { role: "clusterMonitor", db: "admin" }
+          ]
+        })
+        ```
+        *The `clusterMonitor` role is recommended for performance metrics analysis.*
+      </Step>
+      <Step title="Configure Network Access">
+        Ensure CloudThinker can reach your database:
+        - Add CloudThinker IPs to your firewall or security group.
+        - Ensure MongoDB is bound to an accessible IP address in `mongod.conf`.
+      </Step>
+      <Step title="Get Connection String">
+        Your connection string will follow this format:
+        ```
+        mongodb://cloudthinker_readonly:your-secure-password@your-host:27017/admin
+        ```
+      </Step>
+      <Step title="Add Connection in CloudThinker">
+        Navigate to **Connections → MongoDB** and enter the connection string or fill in the host, port, and credentials manually.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="MongoDB Atlas">
+    <Steps>
+      <Step title="Navigate to Database Access">
+        Log in to your MongoDB Atlas dashboard and select **Database Access** from the left sidebar under the Security section.
+      </Step>
+      <Step title="Add New Database User">
+        Click **Add New Database User** and configure the following:
+        - **Authentication Method:** Password
+        - **Username:** `cloudthinker_readonly`
+        - **Password:** Generate a secure password
+        - **Database User Privileges:** Select **Built-in Role** and choose **Read Any Database**.
+      </Step>
+      <Step title="Configure Network Access">
+        Navigate to **Network Access** from the left sidebar:
+        - Click **Add IP Address**.
+        - Add the CloudThinker IP addresses to the IP Access List.
+      </Step>
+      <Step title="Get Connection String">
+        Navigate back to **Databases** (under Deployment), click **Connect** on your cluster, and choose **Drivers**:
+        - Copy the provided connection string.
+        - Replace `<password>` with the password you created.
+        ```
+        mongodb+srv://cloudthinker_readonly:your-secure-password@cluster0.example.mongodb.net/admin
+        ```
+      </Step>
+      <Step title="Add Connection in CloudThinker">
+        Navigate to **Connections → MongoDB** and enter your connection string.
+      </Step>
+    </Steps>
+  </Tab>
+  <Tab title="AWS DocumentDB">
+    <Steps>
+      <Step title="Connect as Admin">
+        Connect to your DocumentDB cluster using `mongosh`:
+        ```bash
+        mongosh --ssl --host docdb-cluster.us-east-1.docdb.amazonaws.com:27017 --sslCAFile global-bundle.pem --username admin --password
+        ```
+      </Step>
+      <Step title="Create Read-Only User">
+        Create a user for CloudThinker with read access:
+        ```javascript
+        use admin
+        db.createUser({
+          user: "cloudthinker_readonly",
+          pwd: "your-secure-password",
+          roles: ["readAnyDatabase"]
+        })
+        ```
+      </Step>
+      <Step title="Configure VPC and Network Access">
+        Ensure CloudThinker can reach your DocumentDB cluster:
+        - DocumentDB requires VPC access. You may need to set up VPC peering or an AWS PrivateLink connection with CloudThinker.
+        - Ensure the associated Security Group allows inbound traffic on port 27017 from CloudThinker.
+      </Step>
+      <Step title="Get Connection String">
+        Format your DocumentDB connection string. It requires specific parameters for TLS and replica sets:
+        ```
+        mongodb://cloudthinker_readonly:your-secure-password@docdb-cluster.us-east-1.docdb.amazonaws.com:27017/admin?tls=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false
+        ```
+      </Step>
+      <Step title="Add Connection in CloudThinker">
+        Navigate to **Connections → MongoDB** and enter your connection string.
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+
+---
+
+## Required Permissions
+
+To get the most out of Tony's analysis, the following roles are recommended:
+
+*   `readAnyDatabase`: Required to analyze queries and index usage across your collections.
+*   `clusterMonitor`: Recommended. Provides access to serverStatus, replSetGetStatus, and other diagnostic commands for performance metrics.
+
+---
+
+## Agent Capabilities
+
+Once connected, [Tony](/guide/agents/tony) can:
+
+| Capability | Description |
+|------------|-------------|
+| **Query Analysis** | Identify slow queries, analyze execution plans (`explain()`) |
+| **Index Recommendations** | Find missing indexes, identify unused indexes |
+| **Performance Metrics** | Monitor connections, memory usage, replication lag |
+
+### Example Prompts
+
+```bash
+@tony analyze slow queries on production MongoDB
+@tony recommend index optimizations for the users collection
+@tony check replication lag on the secondary nodes
+```
+
+---
+
+## Connection Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| **TLS/SSL** | Require TLS for the connection | `true` |
+| **Read Preference** | Which nodes to route read operations to | `primary` |
+| **Connection Timeout** | Seconds to wait for connection | 10 |
+
+---
+
+## Troubleshooting
+
+<Accordion title="Authentication failed">
+- Verify username and password are correct.
+- Ensure the user is created on the `admin` database, or append `?authSource=admin` to your connection string.
+</Accordion>
+
+<Accordion title="Connection refused or Timeout">
+- Check if CloudThinker IPs are added to your Atlas Network Access list or AWS Security Group.
+- For local MongoDB, ensure `bindIp` in `mongod.conf` is not set to only `127.0.0.1`.
+- For DocumentDB, verify your VPC routing and peering configuration.
+</Accordion>
+
+<Accordion title="DocumentDB TLS Errors">
+- Ensure `tls=true` is in the connection string.
+- Check that the appropriate CA certificates are configured if strictly validating.
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Strong passwords** - Use complex, unique passwords for the database user.
+- **TLS encryption** - Always encrypt data in transit (`tls=true`).
+- **Network restrictions** - Restrict database access to CloudThinker IPs via firewalls or Atlas Network Access.
+- **Minimal permissions** - Never grant write or admin roles to the CloudThinker user.
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Tony Agent" icon="database" href="/guide/agents/tony">
+    Database-focused optimization agent
+  </Card>
+  <Card title="PostgreSQL Connection" icon="database" href="/guide/connections/postgresql">
+    Setup instructions for PostgreSQL databases
+  </Card>
+</CardGroup>

--- a/guide/connections/mongodb.mdx
+++ b/guide/connections/mongodb.mdx
@@ -51,7 +51,7 @@ Select your MongoDB platform for specific connection instructions:
           ]
         })
         ```
-        *The `clusterMonitor` role is recommended for performance metrics analysis.*
+        The `clusterMonitor` role is recommended for performance metrics analysis.
       </Step>
       <Step title="Configure Network Access">
         Ensure CloudThinker can reach your database:

--- a/llms.txt
+++ b/llms.txt
@@ -67,6 +67,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Cloudflare](https://docs.cloudthinker.io/guide/connections/cloudflare.md): Connect Cloudflare
 - [PostgreSQL](https://docs.cloudthinker.io/guide/connections/postgresql.md): Connect PostgreSQL databases
 - [MySQL](https://docs.cloudthinker.io/guide/connections/mysql.md): Connect MySQL databases
+- [MongoDB](https://docs.cloudthinker.io/guide/connections/mongodb.md): Connect MongoDB databases
 - [Kubernetes](https://docs.cloudthinker.io/guide/connections/kubernetes.md): Connect Kubernetes clusters
 - [Elasticsearch](https://docs.cloudthinker.io/guide/connections/elasticsearch.md): Connect Elasticsearch
 - [Grafana](https://docs.cloudthinker.io/guide/connections/grafana.md): Connect Grafana


### PR DESCRIPTION
## Summary
- Added detailed connection instructions for MongoDB (Self-hosted, Atlas, DocumentDB)
- Added tabbed layout for platform-specific steps including read-only user creation
- Updated docs.json and llms.txt to include the new page