### PR TITLE
feat(docs): add prerequisites and Azure AD permissions for Microsoft …

### DIFF
--- a/guide/teams-integration.mdx
+++ b/guide/teams-integration.mdx
@@ -8,6 +8,45 @@ Transform your Microsoft Teams workspace into a cloud operations command center.
 
 ---
 
+## Prerequisites
+
+<Warning>
+  The initial setup **must be performed by a user with one of the following Azure AD roles**:
+  - **Global Administrator** — full admin access across all Microsoft 365 services
+  - **Teams Administrator** — admin access scoped to Microsoft Teams
+
+  A regular Microsoft 365 user **cannot** complete the setup. If you don't have one of these roles, ask your IT team to perform the initial connection (Steps 1–3 below). Once the bot is published, any user can interact with it in Teams channels.
+</Warning>
+
+### Required Azure AD Permissions
+
+During the OAuth flow, CloudThinker requests the following Microsoft Graph API permissions:
+
+| Permission | Type | Purpose |
+|---|---|---|
+| `User.Read` | User consent | Read the signed-in user's profile |
+| `Channel.ReadBasic.All` | User consent | List channels in teams |
+| `Team.ReadBasic.All` | User consent | List teams the user belongs to |
+| `TeamsAppInstallation.ReadWriteForTeam` | **Admin consent** | Install the bot into teams |
+| `TeamsAppInstallation.ReadWriteAndConsentForTeam` | **Admin consent** | Install the bot and grant resource-specific consent |
+| `TeamsAppInstallation.ReadWriteSelfForTeam` | **Admin consent** | Manage the bot's own installation |
+| `AppCatalog.ReadWrite.All` | **Admin consent** | Publish the bot to the organization's app catalog |
+| `Organization.Read.All` | **Admin consent** | Read organization information |
+
+Permissions marked **Admin consent** can only be granted by a Global Administrator or Teams Administrator. During the OAuth flow, admins will see a **"Consent on behalf of your organization"** checkbox:
+
+- **Checked** — permissions are granted tenant-wide for all users in the Azure AD tenant. Other admins who connect later won't need to re-consent.
+- **Unchecked** — permissions are granted only for the admin's own account. This is sufficient to complete the setup since the admin personally has the required role to publish the bot.
+
+### Who Should Perform the Setup?
+
+| Your role | What to do |
+|---|---|
+| **Global Admin or Teams Admin** | You can complete the full setup yourself — proceed to Step 1 below |
+| **Regular user** | Ask your Global Admin or Teams Admin to complete Steps 1–3. Once the bot is published, you can use it in any channel where it's installed |
+
+---
+
 ## Setup
 
 <Steps>
@@ -15,10 +54,18 @@ Transform your Microsoft Teams workspace into a cloud operations command center.
     Open the workspace selector in the sidebar, click **Workspace Settings**, then navigate to **Integrations** and find **Microsoft Teams**
   </Step>
   <Step title="Connect with Teams">
-    Click **Connect with Teams** and authenticate via Microsoft OAuth. An Azure AD admin may need to grant consent for your organization.
+    Click **Connect with Teams** and authenticate via Microsoft OAuth.
+
+    <Warning>
+      You **must** be signed in with a **Global Administrator** or **Teams Administrator** account. If you are a regular user, this step will either:
+      - Block you at the Microsoft consent screen, or
+      - Appear to succeed but fail silently when publishing the bot to your organization's app catalog
+
+      If you are not an admin, share this page with your IT team and ask them to perform this step.
+    </Warning>
   </Step>
   <Step title="Install the Bot">
-    Select which Teams to add the CloudThinker bot to and confirm the installation
+    Select which Teams to add the CloudThinker bot to and confirm the installation. The bot is published to your organization's Teams app catalog — this is a one-time action.
   </Step>
   <Step title="Map Teams to Workspaces">
     Map your Microsoft Teams to CloudThinker workspaces so agents know which cloud accounts to operate on
@@ -121,7 +168,7 @@ When an AI code review completes, CloudThinker sends an Adaptive Card notificati
 
 | | Microsoft Teams | Slack |
 |---|---|---|
-| **Admin consent** | Azure AD admin consent required for org-wide install | Slack workspace admin approval |
+| **Admin consent** | Requires Global Administrator or Teams Administrator role in Azure AD (one-time setup) | Slack workspace admin approval |
 | **Rich messages** | Adaptive Cards for structured responses | Block Kit for structured responses |
 | **Code review cards** | Adaptive Card with FactSet severity table | Block Kit with severity emoji indicators |
 | **Workspace mapping** | Team-to-workspace mapping | Channel-to-workspace mapping |
@@ -145,16 +192,36 @@ When an AI code review completes, CloudThinker sends an Adaptive Card notificati
 </Accordion>
 
 <Accordion title="Permission errors">
-- Ask your Azure AD admin to re-grant consent for the CloudThinker app
-- Check workspace admin permissions in CloudThinker
-- Remove and re-add the bot to the team
+- **"Missing required permissions"** — The user who connected does not have the Global Administrator or Teams Administrator role. Ask your IT team to perform the initial connection instead.
+- **"Consent on behalf of your organization"** — During OAuth, an admin can check this box to grant permissions tenant-wide. This is optional — if the connecting user is already an admin, their personal consent is sufficient.
+- **Connection appears successful but bot doesn't work** — This can happen if a non-admin user completes the OAuth flow. The user's personal authentication succeeds, but publishing the bot to the app catalog fails silently. Ask a Global Administrator or Teams Administrator to reconnect.
+- For any other permission errors, check workspace admin permissions in CloudThinker, or try removing and re-adding the bot to the team.
+</Accordion>
+
+<Accordion title="I'm not an admin — how do I set this up?">
+  You need a **Global Administrator** or **Teams Administrator** from your organization to complete the initial connection. Here's what to share with them:
+
+  1. Sign in to CloudThinker (they need a CloudThinker account with admin access to the organization)
+  2. Go to **Workspace Settings → Integrations → Microsoft Teams**
+  3. Click **Connect with Teams** and complete the Microsoft OAuth flow
+  4. The bot will be published to your organization's Teams app catalog
+
+  This is a **one-time setup**. Once the admin completes it, any user in the Teams workspace can interact with the bot by mentioning `@CloudThinker` in channels where the bot is installed.
 </Accordion>
 
 ---
 
 ## Permissions
 
-CloudThinker in Teams uses your workspace's CloudThinker permissions. Users can only access agents and connections their CloudThinker account permits.
+### Azure AD Permissions
+
+The initial connection requires a **Global Administrator** or **Teams Administrator** in Azure AD. This is because CloudThinker needs to publish a bot to your organization's Teams app catalog, which is an admin-level action. This setup is a one-time operation — once the bot is published, no further admin actions are required.
+
+The OAuth flow requests permissions that are granted **tenant-wide** (applying to the entire Azure AD tenant, not per-user). See the [Required Azure AD Permissions](#required-azure-ad-permissions) table above for the full list.
+
+### CloudThinker Permissions
+
+Within Teams, users can only access agents and cloud connections that their CloudThinker account permits. CloudThinker workspace roles apply the same way as they do in the web console.
 
 ---
 

--- a/guide/teams-integration.mdx
+++ b/guide/teams-integration.mdx
@@ -51,7 +51,7 @@ Permissions marked **Admin consent** can only be granted by a Global Administrat
 
 <Steps>
   <Step title="Navigate to Integrations">
-    Open the workspace selector in the sidebar, click **Workspace Settings**, then navigate to **Integrations** and find **Microsoft Teams**
+    Go to [**Admin Settings → Integrations**](https://app.cloudthinker.io/admin-settings/integrations) and find **Microsoft Teams**
   </Step>
   <Step title="Connect with Teams">
     Click **Connect with Teams** and authenticate via Microsoft OAuth.
@@ -164,18 +164,6 @@ When an AI code review completes, CloudThinker sends an Adaptive Card notificati
 
 ---
 
-## Differences from Slack
-
-| | Microsoft Teams | Slack |
-|---|---|---|
-| **Admin consent** | Requires Global Administrator or Teams Administrator role in Azure AD (one-time setup) | Slack workspace admin approval |
-| **Rich messages** | Adaptive Cards for structured responses | Block Kit for structured responses |
-| **Code review cards** | Adaptive Card with FactSet severity table | Block Kit with severity emoji indicators |
-| **Workspace mapping** | Team-to-workspace mapping | Channel-to-workspace mapping |
-| **Authentication** | Microsoft OAuth / Azure AD | Slack OAuth |
-
----
-
 ## Troubleshooting
 
 <Accordion title="Agents not responding">
@@ -202,7 +190,7 @@ When an AI code review completes, CloudThinker sends an Adaptive Card notificati
   You need a **Global Administrator** or **Teams Administrator** from your organization to complete the initial connection. Here's what to share with them:
 
   1. Sign in to CloudThinker (they need a CloudThinker account with admin access to the organization)
-  2. Go to **Workspace Settings → Integrations → Microsoft Teams**
+  2. Go to [**Admin Settings → Integrations → Microsoft Teams**](https://app.cloudthinker.io/admin-settings/integrations)
   3. Click **Connect with Teams** and complete the Microsoft OAuth flow
   4. The bot will be published to your organization's Teams app catalog
 
@@ -217,7 +205,7 @@ When an AI code review completes, CloudThinker sends an Adaptive Card notificati
 
 The initial connection requires a **Global Administrator** or **Teams Administrator** in Azure AD. This is because CloudThinker needs to publish a bot to your organization's Teams app catalog, which is an admin-level action. This setup is a one-time operation — once the bot is published, no further admin actions are required.
 
-The OAuth flow requests permissions that are granted **tenant-wide** (applying to the entire Azure AD tenant, not per-user). See the [Required Azure AD Permissions](#required-azure-ad-permissions) table above for the full list.
+During OAuth, the admin can optionally check **"Consent on behalf of your organization"** to grant permissions tenant-wide. If unchecked, permissions are granted only for the admin's own account, which is still sufficient to complete the setup. See the [Required Azure AD Permissions](#required-azure-ad-permissions) table above for the full list of requested scopes.
 
 ### CloudThinker Permissions
 


### PR DESCRIPTION
…Teams integration

- Introduce a new section detailing prerequisites for setting up Microsoft Teams integration, specifying required Azure AD roles (Global Administrator, Teams Administrator).
- Outline necessary Azure AD permissions for the OAuth flow, including user consent and admin consent requirements.
- Clarify setup responsibilities for different user roles and provide guidance for non-admin users on how to proceed with the setup.