### PR TITLE
fix(docs): update mention commands for CloudThinker integration

### DIFF
--- a/guide/code-review/mention-commands.mdx
+++ b/guide/code-review/mention-commands.mdx
@@ -4,7 +4,7 @@ description: "Interact with CloudThinker directly from MR/PR comments"
 icon: at
 ---
 
-Mention `@cloudthinker` in any merge request or pull request comment to trigger commands — autofix findings, ask questions about the review, or get help.
+Mention `@cloudthinker-ai` in any merge request or pull request comment to trigger commands — autofix findings, ask questions about the review, or get help.
 
 <Warning>
   Mention commands are currently available on **GitLab** and **GitHub** only. Bitbucket and Azure DevOps support is coming soon.
@@ -16,10 +16,10 @@ Mention `@cloudthinker` in any merge request or pull request comment to trigger 
 
 | Command | What it does |
 |---------|-------------|
-| `@cloudthinker help` | Shows available commands as a comment |
-| `@cloudthinker autofix` | Fixes unresolved findings on the source branch |
-| `@cloudthinker autofix stacked pr` | Fixes findings on a new branch and pushes into the current MR/PR |
-| `@cloudthinker <question>` | Ask a free-form question about the code review |
+| `@cloudthinker-ai help` | Shows available commands as a comment |
+| `@cloudthinker-ai autofix` | Fixes unresolved findings on the source branch |
+| `@cloudthinker-ai autofix stacked pr` | Fixes findings on a new branch and pushes into the current MR/PR |
+| `@cloudthinker-ai <question>` | Ask a free-form question about the code review |
 
 ---
 
@@ -27,7 +27,7 @@ Mention `@cloudthinker` in any merge request or pull request comment to trigger 
 
 <Steps>
   <Step title="Comment">
-    Post `@cloudthinker autofix` (or `@cloudthinker autofix stacked pr`) as a comment on the MR/PR
+    Post `@cloudthinker-ai autofix` (or `@cloudthinker-ai autofix stacked pr`) as a comment on the MR/PR
   </Step>
   <Step title="Analyze">
     CloudThinker picks up all unresolved findings from the review
@@ -42,19 +42,19 @@ Mention `@cloudthinker` in any merge request or pull request comment to trigger 
 
 ### Direct vs. Stacked PR
 
-- **`@cloudthinker autofix`** — Commits directly on the MR/PR's source branch. Findings are marked resolved after fixing.
-- **`@cloudthinker autofix stacked pr`** — Creates a new branch and pushes fixes into the current MR/PR's source branch. Findings stay open for your review.
+- **`@cloudthinker-ai autofix`** — Commits directly on the MR/PR's source branch. Findings are marked resolved after fixing.
+- **`@cloudthinker-ai autofix stacked pr`** — Creates a new branch and pushes fixes into the current MR/PR's source branch. Findings stay open for your review.
 
 ---
 
 ## Free-form Questions
 
-Ask anything about the code review by mentioning `@cloudthinker` followed by your question:
+Ask anything about the code review by mentioning `@cloudthinker-ai` followed by your question:
 
 ```
-@cloudthinker why was this function flagged as a security risk?
-@cloudthinker can you explain the performance impact of this change?
-@cloudthinker what's the best way to refactor this?
+@cloudthinker-ai why was this function flagged as a security risk?
+@cloudthinker-ai can you explain the performance impact of this change?
+@cloudthinker-ai what's the best way to refactor this?
 ```
 
 ### Thread-Aware Context
@@ -68,8 +68,8 @@ Ask anything about the code review by mentioning `@cloudthinker` followed by you
 
 | Provider | Mention Trigger | Thread Support | Status |
 |----------|----------------|----------------|--------|
-| GitLab | `@cloudthinker` in MR note | Discussion threads | Available |
-| GitHub | `@cloudthinker` in PR comment | Review comment replies | Available |
+| GitLab | `@cloudthinker-ai` in MR note | Discussion threads | Available |
+| GitHub | `@cloudthinker-ai` in PR comment | Review comment replies | Available |
 | Bitbucket | — | — | Coming soon |
 | Azure DevOps | — | — | Coming soon |
 


### PR DESCRIPTION
- Change mentions from  to  in the documentation for triggering commands in merge requests and pull requests.
- Update command examples and instructions to reflect the new mention format.
- Ensure consistency across all sections regarding the mention commands.