### PR TITLE
docs(kafka): enhance Confluent Cloud scope descriptions and setup profiles

### DIFF
--- a/guide/connections/kafka.mdx
+++ b/guide/connections/kafka.mdx
@@ -119,6 +119,38 @@ Select your Kafka platform for specific connection instructions:
     | **Tableflow** | Manage Tableflow-enabled topics and catalog integrations (e.g., AWS Glue) | `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET` |
     | **Organization metadata** | Organization-level context for Flink resource management | `FLINK_ORG_ID` |
 
+    ## Profiles
+
+    ### Minimal (Kafka-only)
+
+    Required:
+    - `BOOTSTRAP_SERVERS`
+    - `KAFKA_API_KEY`
+    - `KAFKA_API_SECRET`
+    - `KAFKA_CLUSTER_ID`
+    - `KAFKA_ENV_ID`
+
+    **What you can do:** Manage topics (list, create, delete, configure), produce and consume messages, view cluster metadata and topic configurations.
+
+    ### Standard (Kafka + Schema Registry + Cloud Management)
+
+    Add:
+    - `SCHEMA_REGISTRY_ENDPOINT`
+    - `SCHEMA_REGISTRY_API_KEY`
+    - `SCHEMA_REGISTRY_API_SECRET`
+    - `CONFLUENT_CLOUD_API_KEY`
+    - `CONFLUENT_CLOUD_API_SECRET`
+
+    **What you can do:** Everything in Minimal, plus list and inspect data schemas, discover environments and clusters, query operational metrics, and view billing costs.
+
+    ### Advanced (Flink / Tableflow)
+
+    Add one or more optional scope groups as needed:
+    - **Flink:** `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_ID`
+    - **Tableflow:** `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET`
+
+    **What you can do:** Everything in Standard, plus create and manage Flink SQL statements, explore Flink catalogs and databases, run health checks on streaming queries, and manage Tableflow-enabled topics with catalog integrations (e.g., AWS Glue).
+
     ## Connection Field Template
 
     Use this template and fill values for your enabled scopes:
@@ -150,38 +182,6 @@ Select your Kafka platform for specific connection instructions:
       "TABLEFLOW_API_SECRET": "<tableflow-api-secret>"
     }
     ```
-
-    ## Minimal, Standard, and Advanced Setups
-
-    ### Minimal (Kafka-only)
-
-    Required:
-    - `BOOTSTRAP_SERVERS`
-    - `KAFKA_API_KEY`
-    - `KAFKA_API_SECRET`
-    - `KAFKA_CLUSTER_ID`
-    - `KAFKA_ENV_ID`
-
-    **What you can do:** Manage topics (list, create, delete, configure), produce and consume messages, view cluster metadata and topic configurations.
-
-    ### Standard (Kafka + Schema Registry + Cloud Management)
-
-    Add:
-    - `SCHEMA_REGISTRY_ENDPOINT`
-    - `SCHEMA_REGISTRY_API_KEY`
-    - `SCHEMA_REGISTRY_API_SECRET`
-    - `CONFLUENT_CLOUD_API_KEY`
-    - `CONFLUENT_CLOUD_API_SECRET`
-
-    **What you can do:** Everything in Minimal, plus list and inspect data schemas, discover environments and clusters, query operational metrics, and view billing costs.
-
-    ### Advanced (Flink / Tableflow)
-
-    Add one or more optional scope groups as needed:
-    - **Flink:** `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_ID`
-    - **Tableflow:** `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET`
-
-    **What you can do:** Everything in Standard, plus create and manage Flink SQL statements, explore Flink catalogs and databases, run health checks on streaming queries, and manage Tableflow-enabled topics with catalog integrations (e.g., AWS Glue).
   </Tab>
   <Tab title="Self-hosted Kafka">
     For local development or secure internal networks using unauthenticated Kafka (e.g., Confluent Local via Docker), no server-side configuration or user creation is required.
@@ -212,6 +212,31 @@ Select your Kafka platform for specific connection instructions:
         </Note>
       </Step>
     </Steps>
+
+    ## Scope-Based Credential Model
+
+    Self-hosted Kafka uses scope-based configuration. You can start with Kafka-only fields, then add Schema Registry fields later.
+
+    | Scope | What It Unlocks | Endpoint |
+    |-------|-----------------|----------|
+    | **Kafka cluster** | Manage topics (list, create, delete), produce/consume messages | `BOOTSTRAP_SERVERS` |
+    | **Schema Registry** | List, inspect, and delete data schemas | `SCHEMA_REGISTRY_ENDPOINT` |
+
+    ## Profiles
+
+    ### Minimal (Kafka-only)
+
+    Required:
+    - `BOOTSTRAP_SERVERS`
+
+    **What you can do:** Manage topics (list, create, delete), produce and consume messages.
+
+    ### Standard (With Schema Registry)
+
+    Add:
+    - `SCHEMA_REGISTRY_ENDPOINT`
+
+    **What you can do:** Everything in Minimal, plus list, inspect, and delete data schemas.
   </Tab>
 </Tabs>
 

--- a/guide/connections/kafka.mdx
+++ b/guide/connections/kafka.mdx
@@ -96,9 +96,11 @@ Select your Kafka platform for specific connection instructions:
       </Step>
 
       <Step title="Add connection in CloudThinker">
-        In CloudThinker, navigate to **Connections -> Kafka**.
+        In CloudThinker, navigate to **Connections → Kafka**.
 
-        Paste the fields for the scopes you enabled.
+        Create a JSON file with the fields for the scopes you enabled (see [Connection Field Template](#connection-field-template) below). Upload this JSON file in the connection form.
+
+        Required fields depend on your profile — see [Profiles](#profiles) for details.
 
         You can leave optional scope fields empty and add them later.
       </Step>
@@ -191,25 +193,11 @@ Select your Kafka platform for specific connection instructions:
         Ensure the CloudThinker application can reach your Kafka broker at `<broker-name>.<your-domain>:9092`.
       </Step>
       <Step title="Add Connection in CloudThinker">
-        Navigate to **Connections → Kafka** in the CloudThinker dashboard and enter your endpoints. No credentials are required for unauthenticated clusters.
+        In CloudThinker, navigate to **Connections → Kafka**.
 
-        ```json
-        {
-          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092"
-        }
-        ```
+        Create a JSON file with the fields for the scopes you enabled (see [Connection Field Template](#connection-field-template-2) below). Upload this JSON file in the connection form.
 
-        For clusters with Schema Registry, add the endpoint:
-        ```json
-        {
-          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092",
-          "SCHEMA_REGISTRY_ENDPOINT": "http://<schema-registry-host>:<port>"
-        }
-        ```
-
-        <Note>
-        Schema Registry is only required if you are actively using it to manage data schemas.
-        </Note>
+        Required fields depend on your profile — see [Profiles](#profiles-2) below for details.
       </Step>
     </Steps>
 
@@ -217,8 +205,8 @@ Select your Kafka platform for specific connection instructions:
 
     Self-hosted Kafka uses scope-based configuration. You can start with Kafka-only fields, then add Schema Registry fields later.
 
-    | Scope | What It Unlocks | Endpoint |
-    |-------|-----------------|----------|
+    | Scope | What It Unlocks | Typical Fields |
+    |-------|-----------------|----------------|
     | **Kafka cluster** | Manage topics (list, create, delete), produce/consume messages | `BOOTSTRAP_SERVERS` |
     | **Schema Registry** | List, inspect, and delete data schemas | `SCHEMA_REGISTRY_ENDPOINT` |
 
@@ -234,9 +222,20 @@ Select your Kafka platform for specific connection instructions:
     ### Standard (With Schema Registry)
 
     Add:
-    - `SCHEMA_REGISTRY_ENDPOINT`
+    - `SCHEMA_REGISTRY_ENDPOINT` (typically port 8081)
 
     **What you can do:** Everything in Minimal, plus list, inspect, and delete data schemas.
+
+    ## Connection Field Template
+
+    Use this template and fill values for your enabled scopes:
+
+    ```json
+    {
+      "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092",
+      "SCHEMA_REGISTRY_ENDPOINT": "http://<schema-registry-host>:8081"
+    }
+    ```
   </Tab>
 </Tabs>
 
@@ -275,9 +274,10 @@ Once connected, [Alex](/guide/agents/alex) and [Tony](/guide/agents/tony) can:
 ## Troubleshooting
 
 <Accordion title="Connection refused or Timeout">
-- Verify the Kafka cluster is running and accepting connections.
+- Verify the Kafka broker process is running on `<broker-name>.<your-domain>`.
 - Check that the broker port (default 9092) is open and not blocked by firewall.
-- Verify bootstrap servers are correct and reachable from CloudThinker.
+- Verify the bootstrap server address `<broker-name>.<your-domain>:9092` is correct and reachable from CloudThinker.
+- For local development, ensure Kafka is bound to an accessible IP (not just `127.0.0.1`).
 </Accordion>
 
 <Accordion title="Confluent Cloud partial scope fields">
@@ -314,16 +314,16 @@ When using partial scope onboarding, **remove the entire key-value pair** for un
 
 ## Security Best Practices
 
-- **Network restrictions** - Restrict Kafka access to CloudThinker IPs via security groups or firewalls.
-- **Dedicated credentials** - Create a dedicated user/API key for CloudThinker with minimal read-only permissions.
-- **Regular credential rotation** - Rotate API keys and passwords periodically.
+### For Confluent Cloud
 
-### Confluent Cloud Security Notes
+- **Network restrictions** - Restrict Kafka access to CloudThinker IPs via security groups.
+- **Least-privilege access** - Use dedicated API keys with minimal read-only permissions per scope.
+- **Secure credentials** - Store secrets in a secure manager and rotate keys regularly.
 
-- Use least-privilege API keys per scope.
-- Store API secrets in a secure secret manager.
-- Rotate keys regularly.
-- For production, prefer Service Account keys over personal keys.
+### For Self-hosted Kafka
+
+- **Network restrictions** - Restrict broker access to CloudThinker IPs via firewalls.
+- **Private networks** - Keep brokers in private subnets, not exposed to the public internet.
 
 <Note>
 CloudThinker supports partial scope onboarding. If you only provide Kafka scope fields first, you can still create the connection and add Schema Registry, Flink, Cloud API, or Tableflow credentials later.

--- a/guide/connections/kafka.mdx
+++ b/guide/connections/kafka.mdx
@@ -14,8 +14,8 @@ Connect your Apache Kafka clusters to enable [Alex](/guide/agents/alex) (Cloud E
 
 | Platform | Support |
 |----------|---------|
-| **Self-hosted Kafka** | 2.8+ (KRaft mode), 3.x |
 | **Confluent Cloud** | All tiers |
+| **Self-hosted Kafka** | 2.8+ (KRaft mode), 3.x |
 
 ---
 
@@ -24,36 +24,6 @@ Connect your Apache Kafka clusters to enable [Alex](/guide/agents/alex) (Cloud E
 Select your Kafka platform for specific connection instructions:
 
 <Tabs>
-  <Tab title="Self-hosted Kafka">
-    For local development or secure internal networks using unauthenticated Kafka (e.g., Confluent Local via Docker), no server-side configuration or user creation is required.
-
-    <Steps>
-      <Step title="Ensure Network Access">
-        Ensure the CloudThinker application can reach your Kafka broker at `<broker-name>.<your-domain>:9092`.
-      </Step>
-      <Step title="Add Connection in CloudThinker">
-        Navigate to **Connections → Kafka** in the CloudThinker dashboard and enter your endpoints. No credentials are required for unauthenticated clusters.
-
-        ```json
-        {
-          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092"
-        }
-        ```
-
-        For clusters with Schema Registry, add the endpoint:
-        ```json
-        {
-          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092",
-          "SCHEMA_REGISTRY_ENDPOINT": "http://<schema-registry-host>:<port>"
-        }
-        ```
-
-        <Note>
-        Schema Registry is only required if you are actively using it to manage data schemas.
-        </Note>
-      </Step>
-    </Steps>
-  </Tab>
   <Tab title="Confluent Cloud">
     <Steps>
       <Step title="Open Confluent Cloud and pick your environment">
@@ -212,6 +182,36 @@ Select your Kafka platform for specific connection instructions:
     - **Tableflow:** `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET`
 
     **What you can do:** Everything in Standard, plus create and manage Flink SQL statements, explore Flink catalogs and databases, run health checks on streaming queries, and manage Tableflow-enabled topics with catalog integrations (e.g., AWS Glue).
+  </Tab>
+  <Tab title="Self-hosted Kafka">
+    For local development or secure internal networks using unauthenticated Kafka (e.g., Confluent Local via Docker), no server-side configuration or user creation is required.
+
+    <Steps>
+      <Step title="Ensure Network Access">
+        Ensure the CloudThinker application can reach your Kafka broker at `<broker-name>.<your-domain>:9092`.
+      </Step>
+      <Step title="Add Connection in CloudThinker">
+        Navigate to **Connections → Kafka** in the CloudThinker dashboard and enter your endpoints. No credentials are required for unauthenticated clusters.
+
+        ```json
+        {
+          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092"
+        }
+        ```
+
+        For clusters with Schema Registry, add the endpoint:
+        ```json
+        {
+          "BOOTSTRAP_SERVERS": "<broker-name>.<your-domain>:9092",
+          "SCHEMA_REGISTRY_ENDPOINT": "http://<schema-registry-host>:<port>"
+        }
+        ```
+
+        <Note>
+        Schema Registry is only required if you are actively using it to manage data schemas.
+        </Note>
+      </Step>
+    </Steps>
   </Tab>
 </Tabs>
 

--- a/guide/connections/kafka.mdx
+++ b/guide/connections/kafka.mdx
@@ -186,8 +186,6 @@ Select your Kafka platform for specific connection instructions:
     ```
   </Tab>
   <Tab title="Self-hosted Kafka">
-    For local development or secure internal networks using unauthenticated Kafka (e.g., Confluent Local via Docker), no server-side configuration or user creation is required.
-
     <Steps>
       <Step title="Ensure Network Access">
         Ensure the CloudThinker application can reach your Kafka broker at `<broker-name>.<your-domain>:9092`.
@@ -238,14 +236,6 @@ Select your Kafka platform for specific connection instructions:
     ```
   </Tab>
 </Tabs>
-
----
-
-## Add Connection in CloudThinker
-
-Back in the CloudThinker App, navigate to **Connections → Kafka**, add your bootstrap servers and authentication details, and finish.
-
-For **Confluent Cloud**, you can leave optional scope fields empty and add them later.
 
 ---
 
@@ -317,7 +307,6 @@ When using partial scope onboarding, **remove the entire key-value pair** for un
 ### For Confluent Cloud
 
 - **Network restrictions** - Restrict Kafka access to CloudThinker IPs via security groups.
-- **Least-privilege access** - Use dedicated API keys with minimal read-only permissions per scope.
 - **Secure credentials** - Store secrets in a secure manager and rotate keys regularly.
 
 ### For Self-hosted Kafka

--- a/guide/connections/kafka.mdx
+++ b/guide/connections/kafka.mdx
@@ -142,12 +142,12 @@ Select your Kafka platform for specific connection instructions:
 
     | Scope | What It Unlocks | Typical Fields |
     |-------|------------------|----------------|
-    | **Kafka cluster** | Kafka brokers, topic operations, cluster access | `BOOTSTRAP_SERVERS`, `KAFKA_API_KEY`, `KAFKA_API_SECRET`, `KAFKA_CLUSTER_ID`, `KAFKA_ENV_ID`, `KAFKA_REST_ENDPOINT` |
-    | **Schema Registry** | Schema read/write and schema compatibility operations | `SCHEMA_REGISTRY_ENDPOINT`, `SCHEMA_REGISTRY_API_KEY`, `SCHEMA_REGISTRY_API_SECRET` |
-    | **Flink region** | Flink statements and compute pool operations | `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_ID` |
-    | **Cloud resource management** | Confluent Cloud management APIs | `CONFLUENT_CLOUD_API_KEY`, `CONFLUENT_CLOUD_API_SECRET` |
-    | **Tableflow** | Tableflow Iceberg REST catalog operations | `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET` |
-    | **Organization metadata** | Organization-level context | `FLINK_ORG_ID` |
+    | **Kafka cluster** | Manage topics (list, create, delete, configure), produce/consume messages, view cluster metadata | `BOOTSTRAP_SERVERS`, `KAFKA_API_KEY`, `KAFKA_API_SECRET`, `KAFKA_CLUSTER_ID`, `KAFKA_ENV_ID`, `KAFKA_REST_ENDPOINT` |
+    | **Schema Registry** | List, inspect, and delete data schemas | `SCHEMA_REGISTRY_ENDPOINT`, `SCHEMA_REGISTRY_API_KEY`, `SCHEMA_REGISTRY_API_SECRET` |
+    | **Flink region** | Create and manage Flink SQL statements, explore catalogs/databases/tables, health checks and diagnostics | `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_ID` |
+    | **Cloud resource management** | Discover environments and clusters, query operational metrics and billing costs | `CONFLUENT_CLOUD_API_KEY`, `CONFLUENT_CLOUD_API_SECRET` |
+    | **Tableflow** | Manage Tableflow-enabled topics and catalog integrations (e.g., AWS Glue) | `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET` |
+    | **Organization metadata** | Organization-level context for Flink resource management | `FLINK_ORG_ID` |
 
     ## Connection Field Template
 
@@ -192,16 +192,26 @@ Select your Kafka platform for specific connection instructions:
     - `KAFKA_CLUSTER_ID`
     - `KAFKA_ENV_ID`
 
-    ### Standard (Kafka + Schema Registry)
+    **What you can do:** Manage topics (list, create, delete, configure), produce and consume messages, view cluster metadata and topic configurations.
+
+    ### Standard (Kafka + Schema Registry + Cloud Management)
 
     Add:
     - `SCHEMA_REGISTRY_ENDPOINT`
     - `SCHEMA_REGISTRY_API_KEY`
     - `SCHEMA_REGISTRY_API_SECRET`
+    - `CONFLUENT_CLOUD_API_KEY`
+    - `CONFLUENT_CLOUD_API_SECRET`
 
-    ### Advanced (Flink / Cloud API / Tableflow)
+    **What you can do:** Everything in Minimal, plus list and inspect data schemas, discover environments and clusters, query operational metrics, and view billing costs.
 
-    Add one or more optional scope groups as needed.
+    ### Advanced (Flink / Tableflow)
+
+    Add one or more optional scope groups as needed:
+    - **Flink:** `FLINK_REST_ENDPOINT`, `FLINK_API_KEY`, `FLINK_API_SECRET`, `FLINK_COMPUTE_POOL_ID`, `FLINK_ENV_ID`
+    - **Tableflow:** `TABLEFLOW_API_KEY`, `TABLEFLOW_API_SECRET`
+
+    **What you can do:** Everything in Standard, plus create and manage Flink SQL statements, explore Flink catalogs and databases, run health checks on streaming queries, and manage Tableflow-enabled topics with catalog integrations (e.g., AWS Glue).
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Summary

Enhances the Confluent Cloud documentation with detailed scope descriptions and clearer setup tier capabilities.

### Changes

- **Scope-Based Credential Model**: Expanded 'What It Unlocks' column with specific tool capabilities:
  - Kafka cluster: topic management, produce/consume, metadata
  - Schema Registry: list/inspect/delete schemas
  - Flink region: SQL statements, catalogs, health checks
  - Cloud resource management: environments, clusters, metrics, billing
  - Tableflow: topic management, AWS Glue integrations

- **Setup Profiles**: Added 'What you can do' descriptions:
  - **Minimal**: Topic management and messaging
  - **Standard**: Added Cloud Management API (metrics, billing, environments)
  - **Advanced**: Flink SQL, catalogs, health checks, Tableflow with AWS Glue

### Reference

Based on [Confluent MCP Server tools documentation](https://github.com/confluentinc/mcp-confluent/blob/main/README.md)