### PR TITLE
docs: Add ArgoCD connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -124,6 +124,7 @@
               "guide/connections/elasticsearch",
               "guide/connections/grafana",
               "guide/connections/atlassian",
+              "guide/connections/argocd",
               "guide/connections/servicenow",
               "guide/connections/zabbix",
               "guide/connections/sonarqube",

--- a/guide/connections/argocd.mdx
+++ b/guide/connections/argocd.mdx
@@ -1,0 +1,318 @@
+---
+title: ArgoCD
+description: "Connect ArgoCD to CloudThinker for GitOps operations and application management"
+icon: code-branch
+---
+
+# ArgoCD
+
+Connect your ArgoCD instances to enable [Kai](/guide/agents/kai) (Kubernetes Engineer) to analyze deployments, manage applications, and troubleshoot GitOps workflows.
+
+---
+
+## Supported Platforms
+
+| Platform | Support |
+|----------|---------|
+| **Self-hosted ArgoCD** | All versions |
+| **Akuity Platform** | Managed ArgoCD service |
+
+---
+
+## Setup
+
+Select your ArgoCD platform for specific connection instructions:
+
+<Tabs>
+  <Tab title="Self-hosted ArgoCD">
+    For ArgoCD running on your own Kubernetes cluster.
+
+    <Steps>
+      <Step title="Deploy ArgoCD (if not already running)">
+        Create the namespace and apply the ArgoCD manifest:
+        ```bash
+        kubectl create namespace argocd
+        kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+        ```
+
+        Wait for pods to be ready:
+        ```bash
+        kubectl -n argocd wait --for=condition=Ready pod -l app.kubernetes.io/name=argocd-server --timeout=180s
+        ```
+      </Step>
+      <Step title="Access ArgoCD Server">
+        Port-forward the server to make it accessible:
+        ```bash
+        kubectl port-forward svc/argocd-server -n argocd 8888:443 --address 0.0.0.0
+        ```
+
+        For CloudThinker connectivity, use your host IP address instead of `localhost` (the MCP server runs in an isolated network namespace).
+        ```bash
+        hostname -I | awk '{print $1}'
+        ```
+      </Step>
+      <Step title="Get Initial Admin Password">
+        Retrieve the auto-generated admin password:
+        ```bash
+        kubectl -n argocd get secret argocd-initial-admin-secret \
+          -o jsonpath="{.data.password}" | base64 -d
+        ```
+      </Step>
+      <Step title="Install ArgoCD CLI">
+        Install the CLI tool for token generation:
+        ```bash
+        brew install argocd
+        ```
+      </Step>
+      <Step title="Enable API Key Capability">
+        By default, the admin account only has `login` capability. Patch the ConfigMap to add `apiKey`:
+        ```bash
+        kubectl -n argocd patch configmap argocd-cm --type merge \
+          -p '{"data":{"accounts.admin":"apiKey, login"}}'
+        ```
+      </Step>
+      <Step title="Login and Generate Token">
+        Login to ArgoCD:
+        ```bash
+        argocd login <host-ip>:8888 --username admin \
+          --password '<password-from-step-3>' --insecure
+        ```
+
+        Generate the API token:
+        ```bash
+        argocd account generate-token --account admin --insecure
+        ```
+      </Step>
+      <Step title="Verify Connection">
+        Test the token works:
+        ```bash
+        curl -sk https://<host-ip>:8888/api/v1/session/userinfo \
+          -H "Authorization: Bearer <token>"
+        ```
+
+        Expected response: `{"loggedIn":true,"username":"admin","iss":"argocd"}`
+      </Step>
+      <Step title="Configure CloudThinker Connection">
+        In CloudThinker, navigate to **Connections → ArgoCD** and enter:
+
+        - **Base URL**: `https://<host-ip>:8888`
+        - **API Token**: Token from Step 6
+        - **TLS Verification**: Disable (self-signed certificate)
+        - **Read-only Mode**: Enable for safety
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="Akuity Platform">
+    For managed ArgoCD via Akuity Platform.
+
+    <Steps>
+      <Step title="Install Required CLIs">
+        Install ArgoCD CLI:
+        ```bash
+        brew install argocd
+        ```
+
+        Install Akuity CLI:
+        ```bash
+        curl -sSL -o /tmp/akuity \
+          "https://dl.akuity.io/akuity-cli/$(curl -sL https://dl.akuity.io/akuity-cli/stable.txt)/linux/amd64/akuity"
+        chmod +x /tmp/akuity
+        sudo mv /tmp/akuity /usr/local/bin/akuity
+        ```
+      </Step>
+      <Step title="Create Akuity API Key">
+        In the [Akuity Portal](https://akuity.cloud):
+
+        1. Navigate to **Organization** → **API Keys**
+        2. Click **Create API Key**
+        3. Set role to **Owner** (Member role cannot manage instances)
+        4. Save the `AKUITY_API_KEY_ID` and `AKUITY_API_KEY_SECRET`
+
+        Verify the key:
+        ```bash
+        export AKUITY_API_KEY_ID=<your-key-id>
+        export AKUITY_API_KEY_SECRET=<your-key-secret>
+        export AKUITY_SERVER_URL=https://akuity.cloud
+        akuity argocd instance list --organization-id <your-org-id>
+        ```
+      </Step>
+      <Step title="Create ArgoCD Instance">
+        In the Akuity Portal:
+
+        1. Under **Deploy**, go to **ArgoCD** → **Create Instance**
+        2. Name your instance (e.g., `production`)
+        3. Note the instance URL: `<instance-id>.cd.akuity.cloud`
+      </Step>
+      <Step title="Configure Admin Account">
+        In the Akuity Portal:
+
+        1. Go to your ArgoCD instance → **Settings** → **System Accounts**
+        2. Click **Add Account** → Name: `admin`
+        3. Enable both **login** and **apiKey** capabilities
+        4. Set a secure password
+      </Step>
+      <Step title="Login and Generate Token">
+        Login to your Akuity-managed ArgoCD:
+        ```bash
+        argocd login <instance-id>.cd.akuity.cloud --grpc-web \
+          --username admin --password '<your-password>'
+        ```
+
+        Verify account capabilities:
+        ```bash
+        argocd account get --account admin --grpc-web
+        ```
+
+        Generate the API token:
+        ```bash
+        argocd account generate-token --account admin --grpc-web
+        ```
+      </Step>
+      <Step title="Verify Connection">
+        Test the token:
+        ```bash
+        curl -s https://<instance-id>.cd.akuity.cloud/api/v1/session/userinfo \
+          -H "Authorization: Bearer <token>"
+        ```
+
+        Expected response: `{"loggedIn":true,"username":"admin","iss":"argocd"}`
+      </Step>
+      <Step title="Configure CloudThinker Connection">
+        In CloudThinker, navigate to **Connections → ArgoCD** and enter:
+
+        - **Base URL**: `https://<instance-id>.cd.akuity.cloud`
+        - **API Token**: Token from Step 5
+        - **TLS Verification**: Enable (Akuity provides valid TLS certificates)
+        - **Read-only Mode**: Enable for safety
+      </Step>
+    </Steps>
+  </Tab>
+</Tabs>
+
+---
+
+## Connection Options
+
+| Option | Description | Self-hosted | Akuity |
+|--------|-------------|-------------|--------|
+| **TLS Verification** | Validate server certificate | Disabled (self-signed) | Enabled |
+| **API Key Setup** | Enable `apiKey` capability | Patch `argocd-cm` ConfigMap | Portal UI → System Accounts |
+| **Admin Password** | Initial authentication | From `argocd-initial-admin-secret` | Set in Portal UI |
+| **CLI Flags** | Required ArgoCD CLI flags | `--insecure` | `--grpc-web` |
+| **Network Access** | How to reach the server | Use host IP, not localhost | Public URL, no port-forward |
+
+---
+
+## Required Permissions
+
+### Minimum (Read-Only Analysis)
+
+The CloudThinker user needs these ArgoCD RBAC permissions:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: argocd
+data:
+  policy.default: role:readonly
+  policy.csv: |
+    p, role:cloudthinker, applications, get, */*, allow
+    p, role:cloudthinker, applications, list, */*, allow
+    p, role:cloudthinker, repositories, get, *, allow
+    p, role:cloudthinker, repositories, list, *, allow
+    p, role:cloudthinker, clusters, get, *, allow
+    p, role:cloudthinker, clusters, list, *, allow
+    g, cloudthinker, role:cloudthinker
+```
+
+Apply the RBAC policy:
+```bash
+kubectl apply -f argocd-rbac.yaml
+```
+
+### Capabilities Required
+
+| Capability | Purpose |
+|------------|---------|
+| **login** | Authenticate to ArgoCD |
+| **apiKey** | Generate long-lived API tokens |
+
+---
+
+## Agent Capabilities
+
+Once connected, [Kai](/guide/agents/kai) can:
+
+| Capability | Description |
+|------------|-------------|
+| **Application Status** | View sync status, health state, and last sync time |
+| **Deployment Analysis** | Identify out-of-sync applications and failed deployments |
+| **Repository Insights** | Analyze Git repository state and commit history |
+| **Sync Operations** | Trigger manual syncs and monitor progress |
+| **Health Monitoring** | Track application health and resource degradation |
+
+### Example Prompts
+
+```bash
+@kai show me all out-of-sync applications in ArgoCD
+@kai analyze deployment failures for the payment service
+@kai sync the frontend application to latest commit
+@kai check health status of all apps in the production namespace
+@kai list applications with degraded health for the past 24 hours
+```
+
+---
+
+## Troubleshooting
+
+<Accordion title="Cannot connect to ArgoCD server">
+- **Self-hosted**: Ensure you're using the host IP (not `localhost`) in the Base URL
+- Verify the port-forward is running: `kubectl port-forward svc/argocd-server -n argocd 8888:443 --address 0.0.0.0`
+- Check firewall rules allow CloudThinker IPs
+- For private clusters: Set up VPN or bastion access
+</Accordion>
+
+<Accordion title="401 Unauthorized errors">
+- Verify the API token is correct and not expired
+- Ensure the admin account has both `login` and `apiKey` capabilities enabled
+- For self-hosted: Confirm the `argocd-cm` ConfigMap was patched correctly
+- For Akuity: Verify the System Account has both capabilities ticked in the Portal
+</Accordion>
+
+<Accordion title="Cannot generate API token">
+- Check that `apiKey` capability is enabled for the account
+- Verify you're logged in: `argocd account get`
+- For self-hosted: Ensure the `argocd-cm` patch was applied: `kubectl get cm argocd-cm -n argocd -o yaml`
+</Accordion>
+
+<Accordion title="TLS certificate errors">
+- **Self-hosted**: Disable TLS verification in CloudThinker (uses self-signed cert)
+- **Akuity**: Enable TLS verification (uses valid certificates)
+- Check certificate validity: `openssl s_client -connect <host>:<port> -servername <host>`
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Read-only access** - Use read-only RBAC policies for CloudThinker
+- **Token rotation** - Rotate API tokens periodically
+- **Network isolation** - Restrict ArgoCD server access to CloudThinker IPs
+- **Audit logging** - Enable ArgoCD audit logs for all API access
+- **Least privilege** - Grant only `get` and `list` permissions, avoid `create`, `update`, `delete`
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Kai Agent" icon="dharmachakra" href="/guide/agents/kai">
+    Kubernetes and GitOps-focused optimization agent
+  </Card>
+  <Card title="Kubernetes Connection" icon="dharmachakra" href="/guide/connections/kubernetes">
+    Connect Kubernetes clusters for deeper workload analysis
+  </Card>
+</CardGroup>

--- a/llms.txt
+++ b/llms.txt
@@ -73,6 +73,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Elasticsearch](https://docs.cloudthinker.io/guide/connections/elasticsearch.md): Connect Elasticsearch
 - [Grafana](https://docs.cloudthinker.io/guide/connections/grafana.md): Connect Grafana
 - [Atlassian](https://docs.cloudthinker.io/guide/connections/atlassian.md): Connect Atlassian (Jira, Confluence)
+- [ArgoCD](https://docs.cloudthinker.io/guide/connections/argocd.md): Connect ArgoCD for GitOps operations and application management
 - [Flespi](https://docs.cloudthinker.io/guide/connections/flespi.md): Connect Flespi IoT telematics for GPS device management and fleet telemetry
 - [MCP](https://docs.cloudthinker.io/guide/connections/mcp.md): Connect custom tools via Model Context Protocol
 


### PR DESCRIPTION
## Summary

Add comprehensive ArgoCD connection documentation to enable Kai (Kubernetes Engineer) to analyze deployments and manage GitOps workflows.

## Changes

- **New guide**: `guide/connections/argocd.mdx` with 320 lines covering:
  - Self-hosted ArgoCD setup (local Kubernetes)
  - Akuity Platform managed ArgoCD setup
  - API token generation and RBAC configuration
  - Connection troubleshooting and security best practices
  
- **Updated navigation**: `docs.json` - Added ArgoCD to connections menu
- **Updated llms.txt**: Added ArgoCD entry for LLM context

## Coverage

| Platform | Status |
|----------|--------|
| Self-hosted ArgoCD | Full setup with kubectl commands |
| Akuity Platform | Portal-based configuration |

## Features

- Step-by-step setup instructions for both platforms
- Required permissions and RBAC policies
- Agent capabilities and example prompts
- Troubleshooting section with common issues
- Security best practices
- Connection comparison table

## Testing

- [x] Documentation follows existing format and mental model
- [x] All commands validated against actual ArgoCD setup process
- [x] Navigation structure updated in docs.json
- [x] llms.txt synchronized with new page