### PR TITLE
docs: add agent skills and refine docs workflow

### DIFF
--- a/.agents/skills/ship-docs/SKILL.md
+++ b/.agents/skills/ship-docs/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ship-docs
+description: Ship CloudThinker documentation changes with consistent git hygiene. Use for branch naming, staging docs changes, drafting commit messages, PR titles, PR descriptions, and verifying docs-related updates before opening or updating a PR. In dry-run mode, output drafts only and never present unrun actions as completed.
+---
+
+# Ship Docs
+
+## When to Use
+- User asks to commit documentation changes.
+- User asks to prepare or create a PR for docs work.
+- User asks for branch, commit-message, PR-title, or PR-description cleanup.
+
+## Core Rules
+- Only commit or push when the user explicitly asks.
+- Keep docs commits scoped to the documentation task.
+- Default to truthful dry-run behavior until the user asks for git actions.
+- Commit message, PR title, and PR body should explain the user-facing docs outcome, not just list filenames.
+- Include verification notes only for checks that were actually run.
+
+## Branch Naming
+- Default docs branch pattern: `docs/<description>`
+- Use lowercase kebab-case.
+- If the user explicitly requests a different branch name, use that instead.
+
+Examples:
+- `docs/add-argocd-connection-guide`
+- `docs/update-kubernetes-health-monitoring`
+- `docs/refine-doc-skills-workflow`
+
+## Pre-Ship Checklist
+1. Review the final diff.
+2. Confirm the changed docs follow existing repo patterns.
+3. Confirm required companion files were updated when applicable.
+   - `docs.json`
+   - `llms.txt`
+   - relevant `overview.mdx`
+4. Run relevant checks when applicable.
+   - `mintlify broken-links` for new or changed links
+   - Any targeted validation the user requested
+5. Note pre-existing issues separately. Do not fold them into this docs change.
+
+## Dry-Run Mode
+- Default behavior is draft-only output.
+- In dry-run mode, provide:
+  - proposed branch name
+  - draft commit message
+  - draft PR title
+  - draft PR description
+  - checks that would be run
+- Never mark unchecked work as complete.
+- Use honest language such as `Would update`, `Draft`, `Planned`, or unchecked boxes `[ ]`.
+
+## Commit Message Format
+Use a conventional subject line:
+
+```text
+docs: add argocd connection guide
+docs: update kubernetes health monitoring walkthrough
+docs: refine documentation skill workflow
+```
+
+Guidance:
+- Start with `docs:` unless the change is clearly chore-only.
+- Use a short lowercase subject line.
+- Prefer `add`, `update`, `fix`, or `refine` based on intent.
+- Scope the subject to the user-visible outcome.
+
+## PR Title Format
+- Default to the same style as the commit subject.
+- Keep it concise and outcome-focused.
+
+Examples:
+- `docs: add argocd connection guide`
+- `docs: refine write-docs and ship-docs workflow`
+
+## PR Description Template
+Use this structure:
+
+```md
+## Summary
+- Explain the user-facing docs outcome
+- Note any new pages, guidance, or workflow coverage added
+
+## What Changed
+- New files added
+- Existing files updated
+- Navigation / index / overview changes
+
+## Checks
+- [ ] Reviewed against similar docs patterns
+- [ ] Updated `docs.json` when needed
+- [ ] Updated `llms.txt` when needed
+- [ ] Updated relevant `overview.mdx` when needed
+- [ ] Ran `mintlify broken-links` when relevant
+
+## Notes
+- Call out limitations, skipped items, follow-up work, or dry-run status
+```
+
+## Truthful Reporting
+- `[x]` only for work actually completed.
+- `[ ]` for planned, skipped, not-run, or failed checks.
+- If something was intentionally not run, say why.
+- Do not present hypothetical file updates as already done.
+
+## Ask Before Proceeding If
+- The user has not asked you to commit or push yet.
+- The diff includes unrelated changes.
+- Validation failed and the failure source is unclear.
+
+## Never Do
+- Do not commit secrets, `.env` files, or generated junk.
+- Do not create empty commits.
+- Do not push forcefully unless the user explicitly requests it.
+- Do not describe checks as completed if they were not run.
+
+## Final Output to User
+When shipping work, report:
+- branch name
+- commit message used
+- PR title used
+- whether changes were pushed
+- PR URL if created
+- checks run and their outcome

--- a/.agents/skills/write-docs/SKILL.md
+++ b/.agents/skills/write-docs/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: write-docs
+description: Write or update CloudThinker documentation. Use for new MDX pages, existing doc revisions, image-driven docs, and documentation structure work. Always explore similar docs first, decide based on real references and workflow guidance, write in the repo's established pattern, read the result again, and report what came from references versus what was inferred.
+---
+
+# Write Docs
+
+## When to Use
+- User asks to write, rewrite, or expand docs.
+- User provides screenshots/images and wants a new doc.
+- User asks for a new guide, connection page, tutorial, or use case.
+- User asks to restructure existing documentation content.
+
+## Core Rules
+- Follow this flow: **Explore -> Decide -> Write -> Read Again -> Report**.
+- Scan similar docs before writing anything.
+- Match the target doc type instead of inventing a new structure.
+- For procedural docs, require a complete source process from the user or from trusted repo references before drafting.
+- Never invent setup steps, UI behavior, permissions, endpoints, screenshots, or verification results.
+- Never include real credentials, tokens, passwords, customer data, or mock secrets.
+- Keep language concise, direct, and action-oriented.
+
+## Required Repo Awareness
+- This repo is a Mintlify docs site.
+- Main navigation lives in `docs.json`.
+- LLM index lives in `llms.txt` and must stay in sync.
+- Workflow reference: `docs-writing-workflow.md`.
+- Content uses `.mdx` files with required frontmatter.
+
+## Workflow
+
+### 1. Explore
+1. Identify the target doc type.
+   - Connection doc: `guide/connections/*.mdx`
+   - Tutorial: `guide/tutorial/*.mdx`
+   - Use case: `guide/use-cases/*.mdx`
+   - Feature/guide page: nearby `guide/**.mdx`
+2. Read 2-3 similar docs and capture the real pattern.
+   - Section order
+   - Mintlify components used
+   - Tone and heading style
+   - Tables, callouts, related-links pattern
+3. Read `docs-writing-workflow.md` when the task involves a new page, image-driven docs, or workflow uncertainty.
+4. Gather the source-of-truth inputs.
+   - User-provided process/reference material
+   - Existing repo docs with the closest structure
+   - Any relevant overview page for the section
+
+### 2. Decide
+- Decide what is reference-backed versus what would be inferred.
+- If the doc is procedural and the process is incomplete, stop and ask for the missing source material.
+- If the section has an `overview.mdx`, decide whether it should also be updated.
+  - Update the overview when the new page should appear in section cards, summaries, or quick-start guidance.
+  - Do not assume every new page requires an overview change.
+
+### 3. Write
+1. Create or edit the MDX page.
+   - Add required frontmatter: `title`, `description`
+   - Add `icon` when the surrounding pattern uses it
+   - Follow the closest existing doc pattern
+2. Update companion files when needed.
+   - `docs.json` for navigation
+   - `llms.txt` for the LLM index
+   - relevant `overview.mdx` only when the section pattern calls for it
+
+### 4. Read Again
+- Re-read the final doc from top to bottom before reporting completion.
+- Confirm the structure still matches the references.
+- Check for invented claims, accidental scope creep, broken links/paths, and mismatches with frontmatter or index entries.
+
+### 5. Report
+Report back to the user with these sections:
+
+```md
+## References Used
+- <file or source>
+
+## Pattern Followed
+- <which doc family / structure you matched>
+
+## Reference-Backed Content
+- <facts, steps, sections grounded in provided references>
+
+## Inferred Content
+- <anything you inferred from repo patterns or context>
+
+## Follow-Up
+- Suggest using `ship-docs` when the user wants commit / PR preparation
+```
+
+## Pattern Checklist
+
+### All Docs
+- Required frontmatter: `title`, `description`
+- Use sentence-case, direct copy
+- Prefer real sections over long prose walls
+- Add related links only when the surrounding doc family does so
+
+### Connection Docs
+- Usually include: overview/value, prerequisites, setup, permissions, capabilities, troubleshooting, security, related links
+- Reuse existing connection pages for section order
+- If the service is self-hosted or infrastructure-heavy, require exact deployment/setup references first
+- Favor CloudThinker read-only or least-privilege examples when describing credentials
+
+### Tutorials / Walkthroughs
+- Usually center on `<Steps>` and a clear outcome
+- Require the full task flow and expected order from the user
+- Use commands, screenshots, and checkpoints only when provided or directly verifiable
+
+### Image-Driven Docs
+- Follow `docs-writing-workflow.md`
+- Preserve numeric prefixes in image names
+- Use kebab-case descriptions
+- Store images under `/images/...`
+- Use:
+
+```mdx
+<Frame>
+  <img src="/images/path/file.jpg" alt="Descriptive alt text" />
+</Frame>
+<p style={{textAlign: 'center', fontSize: '0.9em', color: '#666', marginTop: '8px'}}>Visible caption</p>
+```
+
+## `docs.json` Rules
+- Add new pages to the correct navigation group.
+- Use page paths without the `.mdx` suffix.
+- Do not create a new group if an existing group already fits.
+- If unsure where a page belongs, inspect nearby siblings first.
+
+## `llms.txt` Rules
+- Keep sections aligned with navigation groups.
+- Use `.md` URLs, not `.mdx`.
+- Description should mirror the page frontmatter description.
+- Add, update, or remove entries whenever the underlying page changes accordingly.
+
+## Ask Before Proceeding If
+- The user did not provide the full process/reference material for a procedural doc.
+- The page location or doc type is unclear.
+- The requested content would expose secrets or unsafe operational guidance.
+- The repo has multiple conflicting patterns and no obvious nearest match.
+
+## Never Do
+- Do not invent process steps.
+- Do not use fake tokens, realistic secrets, or misleading sample credentials.
+- Do not forget `docs.json` / `llms.txt` when page inventory changes.
+- Do not rewrite unrelated docs for style consistency.
+- Do not hide inferred content inside the report; label it explicitly.
+
+## Completion Checklist
+- Similar docs were reviewed first.
+- `docs-writing-workflow.md` was consulted when relevant.
+- MDX frontmatter is valid.
+- Structure matches the nearest existing pattern.
+- `docs.json` updated if navigation changed.
+- `llms.txt` updated if page inventory changed.
+- `overview.mdx` reviewed when section landing-page updates might be needed.
+- No sensitive data or invented process details were introduced.
+- Final report clearly separates reference-backed versus inferred content.
+- If link changes were involved, run `mintlify broken-links` when feasible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,3 +241,5 @@ When updating multiple image references:
 4. Test with `mintlify dev` to verify rendering
 
 @./docs-writing-workflow.md
+@./.agents/skills/write-docs/SKILL.md
+@./.agents/skills/ship-docs/SKILL.md

--- a/docs-writing-workflow.md
+++ b/docs-writing-workflow.md
@@ -1,45 +1,66 @@
 # Documentation writing workflow (for future me)
 
-1. Gather inputs
+1. Explore first
 
-- Receive the image folder and target doc path from the user.
-- Note any required section order or component types (Steps, Tabs, Cards, etc.).
+- Receive the target doc path, source process/reference material, and any image folder from the user.
+- Identify the doc type and read 2-3 similar docs first.
+- Note the real section order, component usage (`Steps`, `Tabs`, `Cards`, etc.), and tone.
+- If there is a relevant section landing page such as `overview.mdx`, inspect it to decide whether the new page should also appear there.
 
-2. Rename images (preserve numeric prefix)
+2. Decide before drafting
+
+- Separate source-backed material from anything you would be inferring from repo patterns.
+- For procedural docs, stop and ask if the user has not provided the full process reference.
+- Decide which companion files may need updates:
+  - `docs.json`
+  - `llms.txt`
+  - contextual `overview.mdx`
+
+3. Rename images (preserve numeric prefix)
 
 - Keep the leading number as-is; convert the rest to concise, kebab-case meaning.
 - Pattern: `01-context-name.jpg`, `02-filter-pane.png`, etc.
 - Aim for names that hint at where they will be used in the doc.
 
-3. Place assets
+4. Place assets
 
 - Move/confirm images in the specified directory (usually under `/images/...`).
 - Ensure the final names match what will be referenced in MDX.
 
-4. Study an example doc for pattern
+5. Study an example doc for pattern
 
 - Open the provided example MDX to mirror structure (front matter, sections, components, tone).
 - Note how images are embedded (typically via `<Frame>`), how headings are sized, and how copy is phrased.
 
-5. Write the new doc
+6. Write the new doc
 
 - Add front matter (`title`, `description`).
 - Follow the example’s section flow (overview, prerequisites, workflow/steps, notes).
 - Use Mintlify components consistently; place images with the renamed files and clear alt text.
 - Keep language concise, action-oriented, and consistent with existing guides.
 
-6. Update `llms.txt`
+7. Update companion files
 
+- Add/update the page in `docs.json` if navigation changed.
 - Add a new entry for the page in the matching section of `/llms.txt`:
   ```
   - [Page Title](https://docs.cloudthinker.io/path/to/page.md): Brief description from frontmatter
   ```
 - If adding a new section/group, add a corresponding `## Section Name` heading.
 - If removing or renaming a page, update or remove its entry.
+- If the section overview should surface this new page, update the relevant `overview.mdx`.
 
-7. Quick checks
+8. Read everything again
 
+- Re-read the final doc top-to-bottom.
+- Re-check companion files touched by the change.
 - Verify all image paths and alt text.
 - Skim for clarity and consistency with the example.
-- Confirm the new page has an entry in `llms.txt`.
 - If possible, run `mintlify broken-links` when link changes are involved.
+
+9. Report references vs inference
+
+- Tell the user which references you followed.
+- State what content was directly grounded in references or user-provided process material.
+- State what you inferred from repo patterns or surrounding docs.
+- If the work is ready to ship, suggest using `ship-docs` for branch / commit / PR prep.


### PR DESCRIPTION
## Summary
- add repo-local `write-docs` and `ship-docs` skills for documentation authoring and shipping workflows
- wire the new skills into the local agent configuration so they are available in this repo
- refine the documentation writing workflow with stronger exploration, companion-file, and reporting guidance

## What Changed
- added `.agents/skills/write-docs/SKILL.md`
- added `.agents/skills/ship-docs/SKILL.md`
- updated `AGENTS.md` and `CLAUDE.md` to load the local skills
- updated `docs-writing-workflow.md` with a more explicit docs authoring flow

## Checks
- [x] Reviewed against similar docs patterns
- [ ] Updated `docs.json` when needed
- [ ] Updated `llms.txt` when needed
- [ ] Updated relevant `overview.mdx` when needed
- [ ] Ran `mintlify broken-links` when relevant

## Notes
- `codedb.snapshot` was intentionally excluded from the shipped changes.
- `.DS_Store` remains uncommitted local junk.