### PR TITLE
docs: add Jenkins connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -135,6 +135,7 @@
               "guide/connections/mysql",
               "guide/connections/kafka",
               "guide/connections/mongodb",
+              "guide/connections/jenkins",
               "guide/connections/redis",
               "guide/connections/kubernetes",
               "guide/connections/elasticsearch",

--- a/guide/connections/jenkins.mdx
+++ b/guide/connections/jenkins.mdx
@@ -1,0 +1,135 @@
+---
+title: Jenkins
+description: "Connect Jenkins to CloudThinker"
+icon: server
+---
+
+# Jenkins
+
+Connect your Jenkins CI/CD server to enable CloudThinker agents to monitor builds, analyze test results, review pipeline logs, and manage job operations.
+
+<Info>
+This guide requires the [Jenkins MCP Server Plugin](https://github.com/jenkinsci/mcp-server-plugin). Cloud-hosted Jenkins services are not supported.
+</Info>
+
+---
+
+## Supported Platforms
+
+| Platform | Support |
+|----------|---------|
+| **Self-hosted Jenkins** | 2.x+ with MCP Server Plugin |
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Access Jenkins">
+    Ensure Jenkins is running and accessible. The default MCP port is `9090`.
+  </Step>
+  <Step title="Configure Root URL">
+    Required for the MCP server to return job results. Configure via Jenkins Script Console:
+
+    ```bash
+    COOKIE_JAR=/tmp/jenkins_cookies
+    CRUMB=$(curl -s -c $COOKIE_JAR -u "admin:<password>" \
+      'http://localhost:9090/crumbIssuer/api/json' | python3 -c "import json,sys; print(json.load(sys.stdin)['crumb'])")
+
+    curl -s -X POST "http://localhost:9090/scriptText" \
+      -b $COOKIE_JAR -u "admin:<password>" -H "Jenkins-Crumb: $CRUMB" \
+      --data-urlencode "script=
+    import jenkins.model.JenkinsLocationConfiguration
+    def loc = JenkinsLocationConfiguration.get()
+    loc.setUrl('http://<host-ip>:9090/')
+    loc.save()
+    println('Root URL set to: ' + loc.getUrl())
+    "
+    ```
+  </Step>
+  <Step title="Add Connection in CloudThinker">
+    Navigate to **Connections → Jenkins** and enter:
+    - **URL**: `http://<host-ip>:9090`
+    - **Username**: `admin`
+    - **API Token**: Your admin password
+  </Step>
+</Steps>
+
+---
+
+## Verify MCP Endpoint
+
+Test before adding to CloudThinker:
+
+```bash
+curl -s http://localhost:9090/mcp-health/
+```
+
+---
+
+## Required Permissions
+
+- **Overall**: Read
+- **Job**: Read, Discover
+- **View**: Read
+
+---
+
+## Agent Capabilities
+
+| Capability | Description |
+|------------|-------------|
+| **Build Monitoring** | List jobs, check build status |
+| **Log Analysis** | Retrieve and search build logs |
+| **Test Results** | View test outcomes |
+| **Pipeline Replay** | Re-run builds with modified scripts |
+| **SCM Integration** | View Git changes and commits |
+| **Job Management** | Trigger builds, check queue status |
+
+### Example Prompts
+
+```bash
+@alex list all Jenkins jobs and their last build status
+@alex show test results for recent builds
+@alex search build logs for errors
+@alex check queue status and identify stuck builds
+```
+
+---
+
+## Troubleshooting
+
+<Accordion title="Connection timeout">
+- Verify Jenkins is running
+- Check port 9090 is accessible
+</Accordion>
+
+<Accordion title="Empty job list">
+- Ensure root URL is configured via Script Console
+</Accordion>
+
+<Accordion title="Authentication failed">
+- Verify admin password is correct
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Dedicated user** - Create a dedicated Jenkins user for CloudThinker
+- **Token rotation** - Rotate API tokens periodically
+- **Minimal permissions** - Grant only required permissions
+- **Network isolation** - Use VPN or private endpoints
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="MCP Connections" icon="plug" href="/guide/connections/mcp">
+    Connect custom tools via Model Context Protocol
+  </Card>
+  <Card title="Kubernetes" icon="dharmachakra" href="/guide/connections/kubernetes">
+    Connect Kubernetes clusters
+  </Card>
+</CardGroup>

--- a/guide/connections/jenkins.mdx
+++ b/guide/connections/jenkins.mdx
@@ -34,9 +34,9 @@ This guide requires the [Jenkins MCP Server Plugin](https://github.com/jenkinsci
     ```bash
     COOKIE_JAR=/tmp/jenkins_cookies
     CRUMB=$(curl -s -c $COOKIE_JAR -u "admin:<password>" \
-      'http://localhost:9090/crumbIssuer/api/json' | python3 -c "import json,sys; print(json.load(sys.stdin)['crumb'])")
+      'http://<host-ip>:9090/crumbIssuer/api/json' | python3 -c "import json,sys; print(json.load(sys.stdin)['crumb'])")
 
-    curl -s -X POST "http://localhost:9090/scriptText" \
+    curl -s -X POST "http://<host-ip>:9090/scriptText" \
       -b $COOKIE_JAR -u "admin:<password>" -H "Jenkins-Crumb: $CRUMB" \
       --data-urlencode "script=
     import jenkins.model.JenkinsLocationConfiguration
@@ -62,7 +62,7 @@ This guide requires the [Jenkins MCP Server Plugin](https://github.com/jenkinsci
 Test before adding to CloudThinker:
 
 ```bash
-curl -s http://localhost:9090/mcp-health/
+curl -s http://<host-ip>:9090/mcp-health/
 ```
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -76,6 +76,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [MySQL](https://docs.cloudthinker.io/guide/connections/mysql.md): Connect MySQL databases
 - [Kafka](https://docs.cloudthinker.io/guide/connections/kafka.md): Connect Kafka on Confluent Cloud with scope-based credentials
 - [MongoDB](https://docs.cloudthinker.io/guide/connections/mongodb.md): Connect MongoDB databases
+- [Jenkins](https://docs.cloudthinker.io/guide/connections/jenkins.md): Connect Jenkins CI/CD server
 - [Redis](https://docs.cloudthinker.io/guide/connections/redis.md): Connect Redis databases (self-hosted, Upstash, Redis Cloud)
 - [Kubernetes](https://docs.cloudthinker.io/guide/connections/kubernetes.md): Connect Kubernetes clusters
 - [Elasticsearch](https://docs.cloudthinker.io/guide/connections/elasticsearch.md): Connect Elasticsearch


### PR DESCRIPTION
## Summary
- Added Jenkins connection guide following repository patterns
- Simplified setup with 3 steps: Access Jenkins → Configure Root URL → Add Connection
- Assumes user already has Jenkins deployed

## What Changed
- `guide/connections/jenkins.mdx` - New connection guide (135 lines)
- `docs.json` - Added Jenkins to navigation
- `llms.txt` - Added Jenkins entry

## Checks
- [x] Reviewed against similar docs patterns (MongoDB, MySQL, PostgreSQL, Grafana)
- [x] Updated `docs.json` when needed
- [x] Updated `llms.txt` when needed
- [ ] Updated relevant `overview.mdx` (not needed)
- [ ] Ran `mintlify broken-links` (not requested)

## Notes
- Branch created from origin/main
- Single commit, 3 files changed
- Follows pattern: no deployment steps, assumes running, focus on connecting