### PR TITLE
docs: rename Reports section to Artifacts

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -194,8 +194,8 @@
             ]
           },
           {
-            "group": "Reports",
-            "pages": ["guide/reports/overview"]
+            "group": "Artifacts",
+            "pages": ["guide/artifacts/overview"]
           },
           {
             "group": "Webhooks",
@@ -283,6 +283,16 @@
       "href": "https://app.cloudthinker.io"
     }
   },
+  "redirects": [
+    {
+      "source": "/guide/reports/overview",
+      "destination": "/guide/artifacts/overview"
+    },
+    {
+      "source": "/guide/reports/:slug*",
+      "destination": "/guide/artifacts/:slug*"
+    }
+  ],
   "footer": {
     "socials": {
       "x": "https://x.com/cloudthinkerio?s=21",

--- a/guide/agents/anna.mdx
+++ b/guide/agents/anna.mdx
@@ -277,7 +277,7 @@ Anna inherits access from all agents she coordinates:
   <Card title="Deep Response Engine" icon="triangle-exclamation" href="/guide/incident/overview">
     Use Anna to coordinate cross-domain incident investigations
   </Card>
-  <Card title="Reports" icon="chart-mixed" href="/guide/reports/overview">
+  <Card title="Artifacts" icon="chart-mixed" href="/guide/artifacts/overview">
     Generate executive reports and dashboards with Anna
   </Card>
   <Card title="Recurring Tasks" icon="calendar-check" href="/guide/recurring-tasks">

--- a/guide/artifacts/overview.mdx
+++ b/guide/artifacts/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Reports & Dashboards
+title: Artifacts
 description: "Generate comprehensive reports, build custom dashboards, and export data for analysis"
 icon: chart-mixed
 ---

--- a/guide/cost-optimization/savings.mdx
+++ b/guide/cost-optimization/savings.mdx
@@ -241,7 +241,7 @@ Set savings goals for your organization:
   <Card title="Configure Webhooks" icon="webhook" href="/guide/webhooks/overview">
     Send savings updates to external systems
   </Card>
-  <Card title="Reports & Analytics" icon="chart-mixed" href="/guide/reports/overview">
+  <Card title="Artifacts & Analytics" icon="chart-mixed" href="/guide/artifacts/overview">
     Generate comprehensive savings reports
   </Card>
 </CardGroup>

--- a/llms.txt
+++ b/llms.txt
@@ -119,9 +119,9 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [SSO Setup](https://docs.cloudthinker.io/guide/security/sso.md): Configure SAML or OIDC single sign-on
 - [SCIM Provisioning](https://docs.cloudthinker.io/guide/security/scim.md): Automate user and group provisioning from your identity provider
 
-## Reports & Webhooks
+## Artifacts & Webhooks
 
-- [Reports & Dashboards](https://docs.cloudthinker.io/guide/reports/overview.md): Generate reports, build dashboards, and export data
+- [Artifacts](https://docs.cloudthinker.io/guide/artifacts/overview.md): Generate reports, build dashboards, and export data
 - [Webhooks](https://docs.cloudthinker.io/guide/webhooks/overview.md): Send CloudThinker events to external systems
 - [Billing](https://docs.cloudthinker.io/guide/billing/overview.md): Manage subscription, billing, credits, and usage quotas
 


### PR DESCRIPTION
## Summary
- Rename sidebar group, page title, and directory from "Reports" → "Artifacts" (per Nhi's suggestion — better reflects the section's scope: reports, dashboards, exports)
- Move `guide/reports/overview.mdx` → `guide/artifacts/overview.mdx`
- Add `redirects` block in `docs.json` so existing `/guide/reports/*` URLs 301 to `/guide/artifacts/*`
- Update inbound `<Card>` links in `guide/agents/anna.mdx` and `guide/cost-optimization/savings.mdx`
- Update `llms.txt` section heading and entry

## Test plan
- [ ] `mintlify dev` — sidebar shows "Artifacts" group
- [ ] Visit `/guide/artifacts/overview` — page title renders as "Artifacts"
- [ ] Visit `/guide/reports/overview` — redirects to new URL
- [ ] `mintlify broken-links` — no broken inbound links

🤖 Generated with [Claude Code](https://claude.com/claude-code)