### PR TITLE
docs: add SSH connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -139,6 +139,7 @@
               "guide/connections/jenkins",
               "guide/connections/redis",
               "guide/connections/kubernetes",
+              "guide/connections/ssh",
               "guide/connections/elasticsearch",
               "guide/connections/grafana",
               "guide/connections/atlassian",

--- a/guide/connections/ssh.mdx
+++ b/guide/connections/ssh.mdx
@@ -1,0 +1,141 @@
+---
+title: SSH
+description: "Connect your own servers to CloudThinker over SSH so agents can run shell commands using key-based authentication and trusted host keys"
+icon: "/images/icons/ssh.svg"
+---
+
+Connect your servers over SSH to let [Alex](/guide/agents/alex) (Cloud Engineer) run shell commands on your hosts: checking disk usage, tailing logs, inspecting services, and diagnosing issues directly on the box.
+
+---
+
+## Prerequisites
+
+| Requirement | Detail |
+|-------------|--------|
+| **Reachable host** | The server must accept inbound SSH from CloudThinker on its SSH port |
+| **Login user** | An existing user account with shell access |
+| **Authorized key** | The public half of your key present in that user's `~/.ssh/authorized_keys` |
+| **Key-based auth enabled** | `sshd` must allow public-key authentication for the user |
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Prepare a Key Pair">
+    Use an existing key pair or generate a dedicated one for CloudThinker:
+
+    ```bash
+    ssh-keygen -t ed25519 -C "cloudthinker" -f ./cloudthinker_key
+    ```
+
+    This produces `cloudthinker_key` (private) and `cloudthinker_key.pub` (public). Both OpenSSH (`-----BEGIN OPENSSH PRIVATE KEY-----`) and PEM (`-----BEGIN RSA/EC PRIVATE KEY-----`) formats are accepted, including `ed25519`, `rsa`, and `ecdsa` keys.
+  </Step>
+  <Step title="Authorize the Public Key">
+    Add the public key to the login user's authorized keys on the server:
+
+    ```bash
+    ssh-copy-id -i ./cloudthinker_key.pub user@server.example.com
+    # or append cloudthinker_key.pub manually to ~/.ssh/authorized_keys
+    ```
+  </Step>
+  <Step title="Add Connection in CloudThinker">
+    Navigate to **Connections → SSH** and enter:
+    - **Host**: hostname or IP, e.g. `server.example.com` or `10.0.0.5`
+    - **User**: the login user, e.g. `ubuntu`
+    - **Port**: SSH port (optional, defaults to `22`)
+    - **Private key**: the full private key, including the `BEGIN`/`END` lines
+    - **Passphrase**: optional, only needed if the private key has one
+
+    CloudThinker tests the connection and, once it succeeds, the connection is ready for your agents to use.
+  </Step>
+</Steps>
+
+---
+
+## When the Server's Identity Changes
+
+The first time you connect, CloudThinker remembers your server's identity. On every later connection, it checks that the server still matches, so you're warned if that identity changes unexpectedly.
+
+If it changes, the connection stops and CloudThinker shows you both the previously trusted fingerprint and the new one. This normally happens after you rebuild a server or rotate its keys. Once you've confirmed the change is expected, choose **Trust new host key** to continue.
+
+<Warning>
+If you didn't expect the server's identity to change, don't trust the new key yet. An unexpected change can mean the connection is being intercepted. Verify the new fingerprint against your server first.
+</Warning>
+
+---
+
+## Agent Capabilities
+
+Once connected, agents run shell commands on your server over SSH:
+
+| Capability | Description |
+|------------|-------------|
+| **System inspection** | Disk, memory, CPU, processes, and service status |
+| **Log analysis** | Read and search application and system logs |
+| **Diagnostics** | Investigate failures, connectivity, and configuration on the host |
+| **Operational checks** | Run read-only commands to report on the server's state |
+
+### Example Prompts
+
+```bash
+@alex check disk usage on the production server and flag filesystems above 80%
+@alex tail the last 100 lines of /var/log/app/error.log and summarize the errors
+@alex show me which processes are using the most memory right now
+@alex check whether the nginx service is running and report its status
+```
+
+<Warning>
+Commands run with the permissions of the login user. Scope that user to what your agents actually need.
+</Warning>
+
+---
+
+## Troubleshooting
+
+<Accordion title="Authentication failed">
+- Confirm the public key is in the login user's `~/.ssh/authorized_keys`
+- Verify the **User** matches an account that key is authorized for
+- Ensure the private key was pasted in full, including the `BEGIN`/`END` lines
+- If the key is passphrase-protected, provide the **Passphrase**
+</Accordion>
+
+<Accordion title="Could not reach the host">
+- Verify the **Host** and **Port** are correct
+- Confirm the server accepts SSH from CloudThinker (firewall, security group, or allowlist)
+- Check that the SSH daemon is running and listening on that port
+</Accordion>
+
+<Accordion title="Host key has changed">
+- Expected after a server rebuild or SSH key rotation: review the new fingerprint and choose **Trust new host key**
+- If the change is unexpected, investigate before re-trusting
+</Accordion>
+
+<Accordion title="Remote command failed">
+- The connection is healthy but the command returned a non-zero exit code
+- Check the command, the user's permissions, and paths on the remote host
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Dedicated key** - Generate a key pair used only for CloudThinker so it can be revoked independently
+- **Least-privilege user** - Connect as a user scoped to only what your agents need
+- **Restrict the key** - Use `command=` and `from=` options in `authorized_keys` to limit what the key can do and where it can connect from
+- **Protect the key** - Use a passphrase-protected private key
+- **Rotate keys** - Replace the key periodically and remove old entries from `authorized_keys`
+- **Verify host keys** - Always confirm a host key change is expected before re-trusting
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Alex Agent" icon="cloud" href="/guide/agents/alex">
+    Cloud engineering and infrastructure operations
+  </Card>
+  <Card title="Kubernetes Connection" icon="/images/icons/kubernetes.svg" href="/guide/connections/kubernetes">
+    Connect clusters for workload analysis and operations
+  </Card>
+</CardGroup>

--- a/images/icons/ssh.svg
+++ b/images/icons/ssh.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#71717A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="m7 11 2-2-2-2"/>
+  <path d="M11 13h4"/>
+  <rect width="18" height="18" x="3" y="3" rx="2"/>
+</svg>

--- a/llms.txt
+++ b/llms.txt
@@ -85,6 +85,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Jenkins](https://docs.cloudthinker.io/guide/connections/jenkins.md): Connect Jenkins CI/CD server
 - [Redis](https://docs.cloudthinker.io/guide/connections/redis.md): Connect Redis databases (self-hosted, Upstash, Redis Cloud)
 - [Kubernetes](https://docs.cloudthinker.io/guide/connections/kubernetes.md): Connect Kubernetes clusters
+- [SSH](https://docs.cloudthinker.io/guide/connections/ssh.md): Connect your own servers over SSH for key-based shell command execution with trusted host keys
 - [Elasticsearch](https://docs.cloudthinker.io/guide/connections/elasticsearch.md): Connect Elasticsearch
 - [Grafana](https://docs.cloudthinker.io/guide/connections/grafana.md): Connect Grafana
 - [Atlassian](https://docs.cloudthinker.io/guide/connections/atlassian.md): Connect Atlassian (Jira, Confluence)


### PR DESCRIPTION
## Summary
- Adds a guide for connecting your own servers to CloudThinker over SSH, so agents (Alex) can run shell commands on your hosts using key-based authentication.
- Covers prerequisites, setup, host key trust, agent capabilities, troubleshooting, and security best practices.

## What Changed
- **New page**: `guide/connections/ssh.mdx`
- **New icon**: `images/icons/ssh.svg` (monochrome terminal glyph, matches the connection-icon convention)
- **Navigation**: registered the page in `docs.json` (Connections group)
- **LLM index**: added an entry in `llms.txt`

## Checks
- [x] Reviewed against similar docs patterns (awx, kubernetes, redis)
- [x] Updated `docs.json`
- [x] Updated `llms.txt`
- [x] `overview.mdx` reviewed — left unchanged (its cards are curated; recent additions like AWX/BetterStack aren't listed there either)
- [ ] `mintlify broken-links` not run — CLI not installed in this environment

## Notes
- Internal engineering notes (`SSH_CONNECTION_FLOW-mr3302.md`) and local tooling dirs were intentionally excluded from this commit.
- Host-key section is written as user-facing guidance; implementation internals were deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)