### PR TITLE
docs: add neon connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -133,6 +133,7 @@
               "guide/connections/azure",
               "guide/connections/cloudflare",
               "guide/connections/postgresql",
+              "guide/connections/neon",
               "guide/connections/mysql",
               "guide/connections/kafka",
               "guide/connections/mongodb",

--- a/guide/connections/neon.mdx
+++ b/guide/connections/neon.mdx
@@ -1,0 +1,109 @@
+---
+title: Neon
+description: "Connect Neon Postgres to CloudThinker with OAuth-powered MCP for project discovery, schema inspection, and database operations"
+icon: "/images/icons/neon.svg"
+---
+
+Connect your Neon account to let CloudThinker agents inspect Neon projects, review database schemas, analyze slow queries, and assist with approved database operations through Neon's hosted MCP server.
+
+Neon uses **OAuth**, so you do not need to create a Neon API key or paste credentials into CloudThinker.
+
+---
+
+## Prerequisites
+
+- A **Neon account** with access to the projects you want CloudThinker to inspect.
+- Permission to authorize CloudThinker through Neon's OAuth flow.
+- A CloudThinker workspace where Neon is not already connected.
+
+<Info>
+CloudThinker supports one Neon connection per workspace. To switch accounts, remove the existing Neon connection and reconnect.
+</Info>
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Open CloudThinker">
+    Navigate to **Connections → Neon** in your CloudThinker workspace.
+  </Step>
+  <Step title="Start the OAuth flow">
+    Click **Connect** to open Neon's authorization page.
+  </Step>
+  <Step title="Authorize CloudThinker">
+    Sign in to the Neon account that owns or can access the projects you want CloudThinker to use, then approve access.
+  </Step>
+  <Step title="Return to CloudThinker">
+    After authorization, CloudThinker stores the OAuth tokens and shows the Neon connection as ready for your agents.
+  </Step>
+</Steps>
+
+<Note>
+There are no environment fields to fill out for the Neon connection.
+</Note>
+
+---
+
+## Required Permissions
+
+CloudThinker inherits the Neon access granted during OAuth.
+
+- **Read operations** include listing projects, inspecting schemas, reviewing metadata, and analyzing slow queries.
+- **Write operations** such as SQL execution, branch changes, migrations, Neon Auth changes, and Data API provisioning require matching Neon access **and** explicit [approval](/guide/approval) in CloudThinker.
+
+---
+
+## Agent Capabilities
+
+Once connected, agents can:
+
+- Discover Neon projects, shared projects, organizations, computes, and tables.
+- Inspect schemas and table metadata.
+- Review slow queries and suggest optimizations.
+- Run SQL or transactions only after explicit user approval.
+- Manage branches, migrations, query tuning, Neon Auth, and Neon Data API provisioning only after explicit user approval.
+
+### Example Prompt
+
+```bash
+@tony Please list my Neon projects and summarize their schemas. Do not create branches, run SQL, change settings, or provision anything.
+```
+
+---
+
+## Troubleshooting
+
+<Accordion title="OAuth flow does not complete">
+You may be signed in to the wrong Neon account, or your browser session may not be signed in to Neon. Sign in to the intended Neon account and retry the CloudThinker Neon connection flow.
+</Accordion>
+
+<Accordion title="CloudThinker says Neon is already connected">
+Only one OAuth Neon connection is allowed per workspace. Use the existing Neon connection or remove it before reconnecting.
+</Accordion>
+
+<Accordion title="Agent cannot find expected Neon projects">
+The OAuth flow may have been completed with a Neon account that lacks access to those projects. Reconnect using the Neon account that owns or has access to the projects.
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Least-privilege account** - Authorize with only the Neon project access CloudThinker needs
+- **Approval for writes** - Keep SQL, branches, migrations, Auth, and Data API changes approval-gated
+- **Read before writing** - Start with project and schema inspection prompts
+- **Reconnect carefully** - Remove the existing workspace connection before switching Neon accounts
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="MCP Connection" icon="/images/icons/mcp.svg" href="/guide/connections/mcp">
+    Connect custom tools and services with MCP
+  </Card>
+  <Card title="Tony Agent" icon="database" href="/guide/agents/tony">
+    Database analysis and optimization
+  </Card>
+</CardGroup>

--- a/guide/connections/overview.mdx
+++ b/guide/connections/overview.mdx
@@ -54,6 +54,9 @@ CloudThinker uses the **[Model Context Protocol (MCP)](/guide/connections/mcp)**
   <Card title="PostgreSQL" icon="/images/icons/postgresql.svg" href="/guide/connections/postgresql">
     Query analysis, performance tuning, optimization
   </Card>
+  <Card title="Neon" icon="/images/icons/neon.svg" href="/guide/connections/neon">
+    Serverless Postgres projects, schemas, and query tuning through OAuth MCP
+  </Card>
   <Card title="MySQL" icon="/images/icons/mysql.svg" href="/guide/connections/mysql">
     Performance monitoring, slow query analysis
   </Card>

--- a/images/icons/neon.svg
+++ b/images/icons/neon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-label="Neon" role="img" viewBox="0 0 24 24">
+  <path fill="#00E599" d="M24 0V24l-9.365-8.045V24H0V0ZM2.942 21.087h8.751V9.563l9.365 8.204V2.919L2.942 2.914Z"/>
+</svg>

--- a/llms.txt
+++ b/llms.txt
@@ -79,6 +79,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Azure](https://docs.cloudthinker.io/guide/connections/azure.md): Connect Microsoft Azure
 - [Cloudflare](https://docs.cloudthinker.io/guide/connections/cloudflare.md): Connect Cloudflare
 - [PostgreSQL](https://docs.cloudthinker.io/guide/connections/postgresql.md): Connect PostgreSQL databases
+- [Neon](https://docs.cloudthinker.io/guide/connections/neon.md): Connect Neon Postgres to CloudThinker with OAuth-powered MCP for project discovery, schema inspection, and database operations
 - [MySQL](https://docs.cloudthinker.io/guide/connections/mysql.md): Connect MySQL databases
 - [Kafka](https://docs.cloudthinker.io/guide/connections/kafka.md): Connect Kafka on Confluent Cloud with scope-based credentials
 - [MongoDB](https://docs.cloudthinker.io/guide/connections/mongodb.md): Connect MongoDB databases


### PR DESCRIPTION
## Summary
- Add a lean Neon connection guide that follows the existing OAuth connection pattern.
- Document OAuth setup, permissions, agent capabilities, troubleshooting, and security guidance without exposing the provider endpoint.

## What Changed
- Added `guide/connections/neon.mdx`.
- Added the Neon icon from the CloudThinker Carbon stack.
- Added Neon to Connections navigation, the connections overview, and `llms.txt`.

## Checks
- [x] Reviewed against similar docs patterns
- [x] Updated `docs.json` when needed
- [x] Updated `llms.txt` when needed
- [x] Updated relevant `overview.mdx` when needed
- [x] Ran targeted docs path checks
- [ ] `mintlify broken-links` passes

## Notes
- `mintlify broken-links` was run and failed on pre-existing unrelated links in `essentials/images.mdx` and `essentials/settings.mdx`; those files were left unchanged.
- The Neon MCP endpoint is intentionally not exposed in the published guide.