### PR TITLE
Add Vercel connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -146,7 +146,6 @@
               "guide/connections/atlassian",
               "guide/connections/argocd",
               "guide/connections/awx",
-              "guide/connections/keycloak",
               "guide/connections/servicenow",
               "guide/connections/zabbix",
               "guide/connections/sonarqube",
@@ -156,6 +155,7 @@
               "guide/connections/pagerduty",
               "guide/connections/flespi",
               "guide/connections/coralogix",
+              "guide/connections/vercel",
               "guide/connections/mcp"
             ]
           },

--- a/guide/connections/vercel.mdx
+++ b/guide/connections/vercel.mdx
@@ -1,0 +1,143 @@
+---
+title: Vercel
+description: "Connect Vercel to CloudThinker for project inventory, deployment inspection, runtime log triage, and domain auditing"
+icon: "/images/icons/vercel.svg"
+---
+
+Connect your Vercel account to enable CloudThinker agents to inventory projects, inspect deployments and build events, fetch runtime logs, audit domains and aliases, and run approval-gated controls like canceling stuck deployments or pausing projects.
+
+Vercel authenticates with an **access token** that CloudThinker passes to the official Vercel MCP server (`@vercel/sdk`). The token's **scope** — personal account or a specific team — determines what the agent can reach. No OAuth flow is required.
+
+---
+
+## Prerequisites
+
+- A **Vercel account** with access to the teams and projects you want to investigate.
+- An **access token** scoped to the right team.
+- Permission to create tokens for that scope.
+
+<Info>
+Scope the token to only the team CloudThinker needs. The connection's read operations never mutate Vercel resources — only the three approval-gated controls do.
+</Info>
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Create an Access Token">
+    In Vercel, go to **Settings → Tokens → Create Token**:
+    - **Name**: `cloudthinker`
+    - **Scope**: pick the **team** (or personal account) CloudThinker should access
+    - **Expiration**: choose a lifetime and plan to rotate
+
+    Copy the token immediately — Vercel shows it only once.
+  </Step>
+  <Step title="Add Connection in CloudThinker">
+    Navigate to **Connections → Vercel** and enter:
+    - **Token**: the access token you just created
+
+    Click **Connect**. CloudThinker starts the Vercel MCP server and shows a **Connected** status.
+  </Step>
+</Steps>
+
+<Warning>
+Copy the access token immediately after creation. You'll need to create a new token if it's lost.
+</Warning>
+
+---
+
+## Connection Details
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **VERCEL_TOKEN** | Vercel access token used as the MCP bearer token | — |
+
+<Note>
+CloudThinker resolves the team and projects from the token's scope, so no manual team ID or URL configuration is required.
+</Note>
+
+---
+
+## Required Permissions
+
+Scope the token to the **team** whose projects, deployments, domains, and logs CloudThinker should reach. Read operations work with any token that can see those resources; the three control operations additionally require the token's scope to allow them **and** explicit [approval](/guide/approval) in CloudThinker.
+
+<Tip>
+Follow least privilege: scope the token to a single team and set an expiration. Keep control operations approval-gated rather than removing the guardrail.
+</Tip>
+
+---
+
+## Agent Capabilities
+
+Once connected, agents have read access to your Vercel projects and deployments.
+
+| Capability | Description |
+|------------|-------------|
+| **Teams & Projects** | List teams and projects, and inspect project domains |
+| **Deployments** | List and inspect deployments, deployment events, and build output |
+| **Runtime Logs** | Fetch runtime logs for error triage |
+| **Domains & Aliases** | Audit domains, domain configuration, and aliases |
+| **Account** | Read the authenticated Vercel user |
+| **Deployment Control** | Cancel deployments, pause and unpause projects — **requires approval** |
+
+<Info>
+`Cancel deployment`, `Pause project`, and `Unpause project` are approval-gated. CloudThinker requests confirmation before running them; read-only operations run without approval.
+</Info>
+
+### Example Prompts
+
+```bash
+@tony list all projects across my Vercel teams with framework and latest deployment status #visualize as a table
+@tony the latest production deployment failed — pull the build events, find the error, and #recommend a fix
+@tony show runtime error logs for my Vercel project over the last 6 hours and #alert on 5xx spikes
+@tony check the domain configuration for my production domains and flag any unverified ones
+```
+
+<Note>
+For accounts with many projects, scope requests to a single team or project so the agent returns focused results.
+</Note>
+
+---
+
+## Troubleshooting
+
+<Accordion title="401 or 403 Unauthorized">
+The token is missing, expired, or revoked. Create a fresh Vercel token and reconnect the Vercel connection.
+</Accordion>
+
+<Accordion title="Agent cannot see expected teams or projects">
+The token's scope does not include those teams. Create a new token scoped to the correct team and reconnect.
+</Accordion>
+
+<Accordion title="CloudThinker says Vercel is already connected">
+Only one Vercel connection is allowed per workspace. Use the existing connection or remove it before reconnecting.
+</Accordion>
+
+<Accordion title="Control action did not run">
+Cancel, pause, and unpause require both a token scope that permits the action and explicit approval in CloudThinker. Approve the action when prompted, and confirm the token's scope allows it.
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Least-privilege scope** - Scope the token to only the team CloudThinker needs
+- **Set an expiration** - Prefer short-lived tokens and rotate them regularly
+- **Approval for controls** - Keep cancel, pause, and unpause approval-gated
+- **Reconnect carefully** - Remove the existing connection before switching tokens
+- **Revoke when unused** - Delete the token in Vercel if you stop using the connection
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="MCP Connection" icon="/images/icons/mcp.svg" href="/guide/connections/mcp">
+    Connect custom tools and services with MCP
+  </Card>
+  <Card title="Approval" icon="shield-check" href="/guide/approval">
+    How approval-gated actions work
+  </Card>
+</CardGroup>

--- a/images/icons/vercel.svg
+++ b/images/icons/vercel.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" fill-rule="evenodd" aria-label="Vercel" role="img" viewBox="0 0 24 24"><path d="M0 12a12 12 0 1 1 24 0 12 12 0 0 1-24 0Zm12-6L5 17.5h14L12 6Z"/></svg>

--- a/llms.txt
+++ b/llms.txt
@@ -92,7 +92,6 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Atlassian](https://docs.cloudthinker.io/guide/connections/atlassian.md): Connect Atlassian (Jira, Confluence)
 - [ArgoCD](https://docs.cloudthinker.io/guide/connections/argocd.md): Connect ArgoCD for GitOps operations and application management
 - [AWX](https://docs.cloudthinker.io/guide/connections/awx.md): Connect Ansible AWX for job template execution, inventory management, and automation workflows
-- [Keycloak](https://docs.cloudthinker.io/guide/connections/keycloak.md): Connect Keycloak for identity and access management operations
 - [Flespi](https://docs.cloudthinker.io/guide/connections/flespi.md): Connect Flespi IoT telematics for GPS device management and fleet telemetry
 - [Better Stack](https://docs.cloudthinker.io/guide/connections/betterstack.md): Connect Better Stack for uptime monitoring, incidents, on-call, and log search
 - [ServiceNow](https://docs.cloudthinker.io/guide/connections/servicenow.md): Connect ServiceNow for incident, change request, problem, and CMDB management
@@ -102,6 +101,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Datadog](https://docs.cloudthinker.io/guide/connections/datadog.md): Connect Datadog for log search, metrics, and infrastructure monitoring
 - [PagerDuty](https://docs.cloudthinker.io/guide/connections/pagerduty.md): Connect PagerDuty for on-call management and incident alerting
 - [Coralogix](https://docs.cloudthinker.io/guide/connections/coralogix.md): Connect Coralogix for log search, metrics, traces, incident triage, and pipeline health
+- [Vercel](https://docs.cloudthinker.io/guide/connections/vercel.md): Connect Vercel to CloudThinker for project inventory, deployment inspection, runtime log triage, and domain auditing
 - [MCP](https://docs.cloudthinker.io/guide/connections/mcp.md): Connect custom tools via Model Context Protocol
 
 ## Agent Configuration


### PR DESCRIPTION
## Summary

Adds a documentation guide for connecting **Vercel** to CloudThinker.

- New connection guide `guide/connections/vercel.mdx` following the existing connection pattern (Coralogix): token setup, connection details, required permissions, agent capabilities, troubleshooting, and security best practices.
- Documents the official Vercel MCP server (`@vercel/sdk`) capabilities — teams/projects, deployments, runtime logs, domains/aliases — and the three approval-gated controls (cancel deployment, pause/unpause project).
- Registers the page in the connections nav (`docs.json`) and `llms.txt`.
- Adds the Vercel icon (`images/icons/vercel.svg`).

## Preview

`/guide/connections/vercel`
