### PR TITLE
Codify follow-existing-pattern rule for docs pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,11 +135,21 @@ The custom `llms.txt` at the project root **must be kept in sync** with the docu
 
 ### Adding New Pages
 
-1. Create `.mdx` file in appropriate directory
-2. Add front matter with `title` and `description` (required — used by `llms.txt` auto-generation)
-3. Update `docs.json` navigation structure
-4. Add entry to `llms.txt` in the matching section
-5. Test locally with `mintlify dev`
+1. **Mirror the nearest sibling page.** Before writing, open an existing page in the same category and follow its section order, Mintlify components, frontmatter, and tone — do not invent a new structure. Match the most complete sibling, not the sparsest.
+2. Create `.mdx` file in appropriate directory
+3. Add front matter with `title` and `description` (required — used by `llms.txt` auto-generation)
+4. Update `docs.json` navigation structure
+5. Add entry to `llms.txt` in the matching section (description drawn from frontmatter)
+6. Test locally with `mintlify dev`
+
+### Adding a Connection Guide (`guide/connections/`)
+
+Mirror an existing connection of the **same auth style**, then keep the canonical section flow:
+
+- **Token/API-key connections** (Vercel, Coralogix, Datadog, Cloudflare) → copy `guide/connections/coralogix.mdx`.
+- **OAuth connections** (Neon) → copy `guide/connections/neon.mdx`.
+
+Canonical section flow: intro (capabilities + auth mechanism) → `Prerequisites` (`<Info>`) → `Setup` (`<Steps>` + `<Warning>`) → `Connection Details` (table) → `Required Permissions` (`<Tip>`) → `Agent Capabilities` (table + `Example Prompts`) → `Troubleshooting` (`<Accordion>`) → `Security Best Practices` → `Related` (`<CardGroup>`). Also add an icon at `images/icons/<name>.svg` and register the page in both `docs.json` and `llms.txt`.
 
 ### Updating Navigation
 


### PR DESCRIPTION
## Summary

Codifies the "follow the existing pattern" convention for documentation pages so new guides stay consistent.

- **Adding New Pages** now leads with "Mirror the nearest sibling page" — follow an existing page's section order, components, frontmatter, and tone; match the most complete sibling, not the sparsest.
- New **Adding a Connection Guide** subsection: which exemplar to copy by auth style (token/API-key → `coralogix.mdx`, OAuth → `neon.mdx`), the canonical section flow, and the icon + `docs.json` + `llms.txt` registration steps.

Companion to #76 (Vercel connection guide), which this rule describes.
