### PR TITLE
docs: add AppDynamics connection guide

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -155,6 +155,7 @@
               "guide/connections/pagerduty",
               "guide/connections/flespi",
               "guide/connections/coralogix",
+              "guide/connections/appdynamics",
               "guide/connections/vercel",
               "guide/connections/mcp"
             ]

--- a/guide/connections/appdynamics.mdx
+++ b/guide/connections/appdynamics.mdx
@@ -1,0 +1,155 @@
+---
+title: AppDynamics
+description: "Connect AppDynamics (Cisco) APM to CloudThinker for application health monitoring, health-rule violation triage, metric review, and error-event analysis"
+icon: "/images/icons/appdynamics.svg"
+---
+
+Connect your AppDynamics (Cisco) APM platform to enable CloudThinker agents to list applications, tiers, nodes, and business transactions, pull performance metrics, and review active health-rule violations and error events across your monitored environment.
+
+AppDynamics authenticates with an **API client** (OAuth2 client credentials) scoped to a Controller account. The connection is **read-only** — agents query the Controller REST API but never mutate AppDynamics resources.
+
+---
+
+## Prerequisites
+
+- An **AppDynamics Controller** (SaaS or on-premises) with the applications you want to monitor.
+- An **API Client** created under your account, with its **Client Name** and **Client Secret**.
+- Your **Controller URL** and **account name**.
+
+<Info>
+Grant the API client a read-only role. CloudThinker only reads application health, metrics, violations, and events — it never modifies AppDynamics configuration.
+</Info>
+
+---
+
+## Setup
+
+<Steps>
+  <Step title="Open the AppDynamics Controller">
+    Sign in to your AppDynamics Controller as an administrator. Your Controller URL follows the format `https://<account>.saas.appdynamics.com` for SaaS, or your on-premises host.
+  </Step>
+  <Step title="Create an API Client">
+    Go to **Settings → Administration → API Clients** and click **Create**:
+    - **Client Name**: `cloudthinker`
+    - **Description**: `Read-only access for CloudThinker agents`
+    - **Roles**: assign a read-only role with access to the applications you want CloudThinker to monitor
+
+    Copy the generated **Client Secret** immediately — it is shown only once.
+  </Step>
+  <Step title="Find Your Account Name">
+    Your account name appears under **Settings → License** or as the subdomain of your Controller URL (e.g. `myaccount` in `https://myaccount.saas.appdynamics.com`).
+  </Step>
+  <Step title="Add Connection in CloudThinker">
+    Navigate to **Connections → AppDynamics** and enter:
+    - **Controller URL**: your Controller base URL
+    - **Account Name**: your AppDynamics account name
+    - **Client Name**: the API client name (e.g. `cloudthinker@myaccount`)
+    - **Client Secret**: the secret you copied
+
+    Click **Connect**. CloudThinker verifies the credentials and shows a **Connected** status.
+  </Step>
+</Steps>
+
+<Warning>
+Copy the Client Secret immediately after creating the API client. AppDynamics shows it only once — if it's lost, you'll need to regenerate the secret.
+</Warning>
+
+---
+
+## Connection Details
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| **APPD_CONTROLLER_URL** | Your AppDynamics Controller base URL | `https://myaccount.saas.appdynamics.com` |
+| **APPD_ACCOUNT_NAME** | Your AppDynamics account name | `myaccount` |
+| **APPD_CLIENT_NAME** | The API client name | `cloudthinker@myaccount` |
+| **APPD_CLIENT_SECRET** | The API client secret | — |
+
+<Note>
+All four fields are required together — AppDynamics OAuth2 client-credentials authentication needs the Controller URL, account, client name, and secret to obtain an access token.
+</Note>
+
+---
+
+## Required Permissions
+
+Assign the API client a **read-only role** with access to the applications CloudThinker should monitor. Read access covers applications, tiers, nodes, business transactions, metrics, health-rule violations, and events.
+
+<Tip>
+Follow least privilege: a read-only role is enough for monitoring and triage. Keep configuration and administration permissions off the client CloudThinker uses.
+</Tip>
+
+---
+
+## Agent Capabilities
+
+Once connected, agents have read access to your AppDynamics APM data.
+
+| Capability | Description |
+|------------|-------------|
+| **Discovery** | Summarize the environment — applications, tiers, nodes, and recent health signals |
+| **Application Health** | List applications and flag health-rule violations or degraded business transactions |
+| **Violation Triage** | List and inspect active health-rule violations, ordered by severity |
+| **Metric Review** | Pull response time, calls per minute, and error rate for applications and business transactions |
+| **Event Analysis** | Retrieve recent error events and summarize top error types by affected tier |
+
+### Example Prompts
+
+```bash
+@alex list all AppDynamics applications and flag any with a Health Rule violation or degraded Business Transaction error rate
+@alex list all active Health Rule violations across AppDynamics applications ordered by severity and #recommend remediation steps
+@alex pull the average response time and error rate for the top business transactions in the checkout application over the last hour
+@alex retrieve the most recent application error events in AppDynamics and #summarize the top error types by frequency with affected tiers
+```
+
+<Note>
+For large environments, scope requests to a named application and a short time window so the agent returns focused results.
+</Note>
+
+---
+
+## Troubleshooting
+
+<Accordion title="401 or 403 Unauthorized">
+The client name or secret is wrong, or the API client lacks the required role. Verify the **Client Name** and **Client Secret**, confirm the client has a read-only role assigned, and reconnect.
+</Accordion>
+
+<Accordion title="Connection refused or timeout">
+The Controller URL is unreachable from CloudThinker. Verify the **Controller URL** is correct and accessible, and that on-premises Controllers allow inbound connections.
+</Accordion>
+
+<Accordion title="Account not found">
+The account name doesn't match the Controller. Check **Settings → License** or your Controller subdomain and update **APPD_ACCOUNT_NAME**.
+</Accordion>
+
+<Accordion title="No applications or metrics found">
+The API client's role has no access to the applications, or the account has no matching data. Confirm the role grants read access to the target applications, then retry with a known application name.
+</Accordion>
+
+<Accordion title="Large or noisy output">
+Unbounded application or metric queries return too much data. Scope requests to a named application and a short time window so results stay focused.
+</Accordion>
+
+---
+
+## Security Best Practices
+
+- **Dedicated API client** - Create a dedicated API client for CloudThinker rather than reusing an existing one
+- **Read-only role** - Assign only a read-only role; keep configuration and admin permissions off the client
+- **Least privilege** - Grant access only to the applications CloudThinker needs to monitor
+- **HTTPS only** - Always use an HTTPS Controller URL
+- **Secret rotation** - Rotate the client secret regularly
+- **Revoke when unused** - Delete the API client in AppDynamics if you stop using the connection
+
+---
+
+## Related
+
+<CardGroup cols={2}>
+  <Card title="Datadog Connection" icon="/images/icons/datadog.svg" href="/guide/connections/datadog">
+    APM, metrics, and monitoring
+  </Card>
+  <Card title="SigNoz Connection" icon="/images/icons/signoz.svg" href="/guide/connections/signoz">
+    Traces, metrics, and logs in one place
+  </Card>
+</CardGroup>

--- a/images/icons/appdynamics.svg
+++ b/images/icons/appdynamics.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" aria-label="AppDynamics" role="img" viewBox="0 0 24 24">
+  <g transform="translate(.267 .267)scale(.36667)">
+    <circle cx="32" cy="32" r="30" fill="#262e3d"/>
+    <path fill="#00b0a1" d="m18 46 12-28h4l12 28h-5l-3-7H26l-3 7zm10.5-12h7L32 24.5z"/>
+    <path fill="#00b0a1" d="M45 18a4.5 4.5 0 1 1 0 9 4.5 4.5 0 0 1 0-9"/>
+  </g>
+</svg>

--- a/llms.txt
+++ b/llms.txt
@@ -101,6 +101,7 @@ Users interact with agents using natural language in a chat interface. Mention a
 - [Datadog](https://docs.cloudthinker.io/guide/connections/datadog.md): Connect Datadog for log search, metrics, and infrastructure monitoring
 - [PagerDuty](https://docs.cloudthinker.io/guide/connections/pagerduty.md): Connect PagerDuty for on-call management and incident alerting
 - [Coralogix](https://docs.cloudthinker.io/guide/connections/coralogix.md): Connect Coralogix for log search, metrics, traces, incident triage, and pipeline health
+- [AppDynamics](https://docs.cloudthinker.io/guide/connections/appdynamics.md): Connect AppDynamics (Cisco) APM for application health monitoring, health-rule violation triage, metric review, and error-event analysis
 - [Vercel](https://docs.cloudthinker.io/guide/connections/vercel.md): Connect Vercel to CloudThinker for project inventory, deployment inspection, runtime log triage, and domain auditing
 - [MCP](https://docs.cloudthinker.io/guide/connections/mcp.md): Connect custom tools via Model Context Protocol
 


### PR DESCRIPTION
## Summary
- Adds a read-only **AppDynamics (Cisco) APM** connection guide so users can connect AppDynamics to CloudThinker for application health monitoring, health-rule violation triage, metric review, and error-event analysis.
- Documents API-client (OAuth2 client-credentials) setup, connection fields, required permissions, agent capabilities, example prompts, troubleshooting, and security best practices.

## What Changed
- **New:** `guide/connections/appdynamics.mdx` — connection guide mirroring the canonical read-only observability pattern (Coralogix/Zabbix).
- **New:** `images/icons/appdynamics.svg` — AppDynamics brand icon.
- **Updated:** `docs.json` — registered the page in the Connections navigation group.
- **Updated:** `llms.txt` — added the page to the Connections section.

## Checks
- [x] Reviewed against similar docs patterns (Coralogix / Zabbix observability guides)
- [x] Updated `docs.json`
- [x] Updated `llms.txt`
- [x] `docs.json` validated as valid JSON
- [ ] `overview.mdx` — not applicable (connections overview lists categories, not every page)
- [ ] Ran `mintlify broken-links` — mintlify CLI not installed in this environment; not run

## Notes
- Source of truth: cloud-cost-optimization MR !3659 (read-only AppDynamics connector).
- Some in-product UI details (Controller "API Clients" navigation, connect-form field labels) were inferred from AppDynamics conventions since they weren't in the MR — worth a quick confirm against the live UI.
- Branch was pushed to the `nhantran102/docs` fork (no write access to `nhat-tranvan/docs`); PR opens from the fork into `nhat-tranvan:main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)